### PR TITLE
Add .clang-format and format all files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Google
+IndentPPDirectives: BeforeHash
+ColumnLimit: 79

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ RELEASE_DIR     = $(BUILD_DIR)/release
 RELEASE_TARGET  = $(RELEASE_DIR)/$(TARGET_EXEC)
 RELEASE_OBJS   := $(addprefix $(RELEASE_DIR)/, $(OBJS))
 
-.PHONY: debug release all clean
+.PHONY: debug release all clean format
 
 # default; target if run as `make`
 debug: $(DEBUG_TARGET)
@@ -55,5 +55,8 @@ all: debug release
 
 clean:
 	rm -rf $(BUILD_DIR)
+
+format:
+	 clang-format -i --style=file **/*.c **/*.h
 
 -include $(DEPS)

--- a/cli/internal.h
+++ b/cli/internal.h
@@ -6,14 +6,13 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <pocketlang.h>
-
 #include <assert.h>
 #include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+#include <pocketlang.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 // Note that the cli itself is not a part of the pocketlang compiler, instead
 // it's a host application to run pocketlang from the command line. We're
@@ -24,14 +23,15 @@
 // pocketlang contain 2 headers (we'll always try to be minimal).
 #include "common.h"
 
-#define CLI_NOTICE                                                            \
-  "PocketLang " PK_VERSION_STRING " (https://github.com/ThakeeNathees/pocketlang/)\n" \
-  "Copyright(c) 2020 - 2021 ThakeeNathees.\n"                                 \
+#define CLI_NOTICE                                    \
+  "PocketLang " PK_VERSION_STRING                     \
+  " (https://github.com/ThakeeNathees/pocketlang/)\n" \
+  "Copyright(c) 2020 - 2021 ThakeeNathees.\n"         \
   "Free and open source software under the terms of the MIT license.\n"
 
- // FIXME: the vm user data of cli.
+// FIXME: the vm user data of cli.
 typedef struct {
   bool repl_mode;
 } VmUserData;
 
-#endif // COMMON_H
+#endif  // COMMON_H

--- a/cli/main.c
+++ b/cli/main.c
@@ -5,7 +5,6 @@
 
 #include "internal.h"
 #include "modules.h"
-
 #include "thirdparty/argparse/argparse.h"
 
 // FIXME: Everything below here is temporary and for testing.
@@ -23,28 +22,27 @@ void onResultDone(PKVM* vm, PkStringPtr result) {
 
 void errorFunction(PKVM* vm, PkErrorType type, const char* file, int line,
                    const char* message) {
-
   VmUserData* ud = (VmUserData*)pkGetUserData(vm);
   bool repl = (ud) ? ud->repl_mode : false;
 
   if (type == PK_ERROR_COMPILE) {
-
-    if (repl) fprintf(stderr, "Error: %s\n", message);
-    else fprintf(stderr, "Error: %s\n       at \"%s\":%i\n",
-                 message, file, line);
+    if (repl)
+      fprintf(stderr, "Error: %s\n", message);
+    else
+      fprintf(stderr, "Error: %s\n       at \"%s\":%i\n", message, file, line);
 
   } else if (type == PK_ERROR_RUNTIME) {
     fprintf(stderr, "Error: %s\n", message);
 
   } else if (type == PK_ERROR_STACKTRACE) {
-    if (repl) fprintf(stderr, "  %s() [line:%i]\n", message, line);
-    else fprintf(stderr, "  %s() [\"%s\":%i]\n", message, file, line);
+    if (repl)
+      fprintf(stderr, "  %s() [line:%i]\n", message, line);
+    else
+      fprintf(stderr, "  %s() [\"%s\":%i]\n", message, file, line);
   }
 }
 
-void writeFunction(PKVM* vm, const char* text) {
-  fprintf(stdout, "%s", text);
-}
+void writeFunction(PKVM* vm, const char* text) { fprintf(stdout, "%s", text); }
 
 PkStringPtr readFunction(PKVM* vm) {
   PkStringPtr result;
@@ -91,7 +89,6 @@ PkStringPtr resolvePath(PKVM* vm, const char* from, const char* path) {
 }
 
 PkStringPtr loadScript(PKVM* vm, const char* path) {
-
   PkStringPtr result;
   result.on_done = onResultDone;
 
@@ -141,32 +138,32 @@ static PKVM* intializePocketVM() {
 }
 
 int main(int argc, const char** argv) {
-
   // Parse command line arguments.
 
   const char* usage[] = {
-    "pocket ... [-c cmd | file] ...",
-    NULL,
+      "pocket ... [-c cmd | file] ...",
+      NULL,
   };
 
   const char* cmd = NULL;
   int debug = false, help = false, quiet = false, version = false;
   struct argparse_option cli_opts[] = {
       OPT_STRING('c', "cmd", (void*)&cmd,
-        "Evaluate and run the passed string.", NULL, 0, 0),
+                 "Evaluate and run the passed string.", NULL, 0, 0),
 
       OPT_BOOLEAN('d', "debug", (void*)&debug,
-        "Compile and run the debug version.", NULL, 0, 0),
+                  "Compile and run the debug version.", NULL, 0, 0),
 
-      OPT_BOOLEAN('h', "help",  (void*)&help,
-        "Prints this help message and exit.", NULL, 0, 0),
+      OPT_BOOLEAN('h', "help", (void*)&help,
+                  "Prints this help message and exit.", NULL, 0, 0),
 
-      OPT_BOOLEAN('q', "quiet", (void*)&quiet,
-        "Don't print version and copyright statement on REPL startup.",
-        NULL, 0, 0),
+      OPT_BOOLEAN(
+          'q', "quiet", (void*)&quiet,
+          "Don't print version and copyright statement on REPL startup.", NULL,
+          0, 0),
 
       OPT_BOOLEAN('v', "version", &version,
-        "Prints the pocketlang version and exit.", NULL, 0, 0),
+                  "Prints the pocketlang version and exit.", NULL, 0, 0),
       OPT_END(),
   };
 
@@ -175,12 +172,12 @@ int main(int argc, const char** argv) {
   argparse_init(&argparse, cli_opts, usage, 0);
   argc = argparse_parse(&argparse, argc, argv);
 
-  if (help) { // pocket --help.
+  if (help) {  // pocket --help.
     argparse_usage(&argparse);
     return 0;
   }
 
-  if (version) { // pocket --version
+  if (version) {  // pocket --version
     fprintf(stdout, "pocketlang %s\n", PK_VERSION_STRING);
     return 0;
   }
@@ -198,16 +195,16 @@ int main(int argc, const char** argv) {
   PkCompileOptions options = pkNewCompilerOptions();
   options.debug = debug;
 
-  if (cmd != NULL) { // pocket -c "print('foo')"
+  if (cmd != NULL) {  // pocket -c "print('foo')"
 
-    PkStringPtr source = { cmd, NULL, NULL, 0, 0 };
-    PkStringPtr path = { "$(Source)", NULL, NULL, 0, 0 };
+    PkStringPtr source = {cmd, NULL, NULL, 0, 0};
+    PkStringPtr path = {"$(Source)", NULL, NULL, 0, 0};
     PkResult result = pkInterpretSource(vm, source, path, NULL);
     exitcode = (int)result;
 
-  } else if (argc == 0) { // Run on REPL mode.
+  } else if (argc == 0) {  // Run on REPL mode.
 
-   // Print the copyright and license notice, if --quiet not set.
+    // Print the copyright and license notice, if --quiet not set.
     if (!quiet) {
       printf("%s", CLI_NOTICE);
     }
@@ -215,7 +212,7 @@ int main(int argc, const char** argv) {
     options.repl_mode = true;
     exitcode = repl(vm, &options);
 
-  } else { // pocket file.pk ...
+  } else {  // pocket file.pk ...
 
     PkStringPtr resolved = resolvePath(vm, ".", argv[0]);
     PkStringPtr source = loadScript(vm, resolved.string);

--- a/cli/modules.c
+++ b/cli/modules.c
@@ -15,9 +15,7 @@
 // callback.
 #define FREE_OBJ(ptr) free(ptr)
 
-void initObj(Obj* obj, ObjType type) {
-  obj->type = type;
-}
+void initObj(Obj* obj, ObjType type) { obj->type = type; }
 
 void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
   Obj* obj = (Obj*)instance;
@@ -31,7 +29,7 @@ void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
     }
   }
 
-  return; // Attribute not found.
+  return;  // Attribute not found.
 }
 
 bool objSetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
@@ -54,7 +52,8 @@ void freeObj(PKVM* vm, void* instance, uint32_t id) {
   if (obj->type == OBJ_FILE) {
     File* file = (File*)obj;
     if (!file->closed) {
-      if (fclose(file->fp) != 0) { /* TODO: error! */ }
+      if (fclose(file->fp) != 0) { /* TODO: error! */
+      }
       file->closed = true;
     }
   }
@@ -64,7 +63,8 @@ void freeObj(PKVM* vm, void* instance, uint32_t id) {
 
 const char* getObjName(uint32_t id) {
   switch ((ObjType)id) {
-    case OBJ_FILE: return "File";
+    case OBJ_FILE:
+      return "File";
   }
   return NULL;
 }
@@ -74,15 +74,15 @@ const char* getObjName(uint32_t id) {
 /*****************************************************************************/
 
 #include "thirdparty/cwalk/cwalk.h"
-  #if defined(_WIN32) && (defined(_MSC_VER) || defined(__TINYC__))
+#if defined(_WIN32) && (defined(_MSC_VER) || defined(__TINYC__))
   #include "thirdparty/dirent/dirent.h"
 #else
   #include <dirent.h>
 #endif
 
 #if defined(_WIN32)
-  #include <windows.h>
   #include <direct.h>
+  #include <windows.h>
   #define get_cwd _getcwd
 #else
   #include <unistd.h>
@@ -97,9 +97,7 @@ const char* getObjName(uint32_t id) {
 /* PUBLIC FUNCTIONS                                                          */
 /*****************************************************************************/
 
-bool pathIsAbsolute(const char* path) {
-  return cwk_path_is_absolute(path);
-}
+bool pathIsAbsolute(const char* path) { return cwk_path_is_absolute(path); }
 
 void pathGetDirName(const char* path, size_t* length) {
   cwk_path_get_dirname(path, length);
@@ -110,7 +108,7 @@ size_t pathNormalize(const char* path, char* buff, size_t buff_size) {
 }
 
 size_t pathJoin(const char* path_a, const char* path_b, char* buffer,
-  size_t buff_size) {
+                size_t buff_size) {
   return cwk_path_join(path_a, path_b, buffer, buff_size);
 }
 
@@ -134,7 +132,7 @@ static inline bool pathIsDirectoryExists(const char* path) {
     closedir(dir);
     return true;
   } else if (errno == ENOENT) { /* Directory does not exist. */
-  } else { /* opendir() failed for some other reason. */
+  } else {                      /* opendir() failed for some other reason. */
   }
 
   return false;
@@ -145,7 +143,6 @@ static inline bool pathIsExists(const char* path) {
 }
 
 static inline size_t pathAbs(const char* path, char* buff, size_t buff_size) {
-
   char cwd[FILENAME_MAX];
 
   if (get_cwd(cwd, sizeof(cwd)) == NULL) {
@@ -183,7 +180,7 @@ static void _pathAbspath(PKVM* vm) {
 }
 
 static void _pathRelpath(PKVM* vm) {
-  const char* from, * path;
+  const char *from, *path;
   if (!pkGetArgString(vm, 1, &from, NULL)) return;
   if (!pkGetArgString(vm, 2, &path, NULL)) return;
 
@@ -194,18 +191,18 @@ static void _pathRelpath(PKVM* vm) {
   pathAbs(path, abs_path, sizeof(abs_path));
 
   char result[FILENAME_MAX];
-  size_t len = cwk_path_get_relative(abs_from, abs_path,
-    result, sizeof(result));
+  size_t len =
+      cwk_path_get_relative(abs_from, abs_path, result, sizeof(result));
   pkReturnStringLength(vm, result, len);
 }
 
 static void _pathJoin(PKVM* vm) {
-  const char* paths[MAX_JOIN_PATHS + 1]; // +1 for NULL.
+  const char* paths[MAX_JOIN_PATHS + 1];  // +1 for NULL.
   int argc = pkGetArgc(vm);
 
   if (argc > MAX_JOIN_PATHS) {
-    pkSetRuntimeError(vm, "Cannot join more than " STRINGIFY(MAX_JOIN_PATHS)
-                           "paths.");
+    pkSetRuntimeError(
+        vm, "Cannot join more than " STRINGIFY(MAX_JOIN_PATHS) "paths.");
     return;
   }
 
@@ -288,19 +285,19 @@ static void _pathIsDir(PKVM* vm) {
 void registerModulePath(PKVM* vm) {
   PkHandle* path = pkNewModule(vm, "path");
 
-  pkModuleAddFunction(vm, path, "setunix",   _pathSetStyleUnix, 1);
-  pkModuleAddFunction(vm, path, "getcwd",    _pathGetCWD,       0);
-  pkModuleAddFunction(vm, path, "abspath",   _pathAbspath,      1);
-  pkModuleAddFunction(vm, path, "relpath",   _pathRelpath,      2);
-  pkModuleAddFunction(vm, path, "join",      _pathJoin,        -1);
-  pkModuleAddFunction(vm, path, "normalize", _pathNormalize,    1);
-  pkModuleAddFunction(vm, path, "basename",  _pathBaseName,     1);
-  pkModuleAddFunction(vm, path, "dirname",   _pathDirName,      1);
-  pkModuleAddFunction(vm, path, "isabspath", _pathIsPathAbs,    1);
-  pkModuleAddFunction(vm, path, "getext",    _pathGetExtension, 1);
-  pkModuleAddFunction(vm, path, "exists",    _pathExists,       1);
-  pkModuleAddFunction(vm, path, "isfile",    _pathIsFile,       1);
-  pkModuleAddFunction(vm, path, "isdir",     _pathIsDir,        1);
+  pkModuleAddFunction(vm, path, "setunix", _pathSetStyleUnix, 1);
+  pkModuleAddFunction(vm, path, "getcwd", _pathGetCWD, 0);
+  pkModuleAddFunction(vm, path, "abspath", _pathAbspath, 1);
+  pkModuleAddFunction(vm, path, "relpath", _pathRelpath, 2);
+  pkModuleAddFunction(vm, path, "join", _pathJoin, -1);
+  pkModuleAddFunction(vm, path, "normalize", _pathNormalize, 1);
+  pkModuleAddFunction(vm, path, "basename", _pathBaseName, 1);
+  pkModuleAddFunction(vm, path, "dirname", _pathDirName, 1);
+  pkModuleAddFunction(vm, path, "isabspath", _pathIsPathAbs, 1);
+  pkModuleAddFunction(vm, path, "getext", _pathGetExtension, 1);
+  pkModuleAddFunction(vm, path, "exists", _pathExists, 1);
+  pkModuleAddFunction(vm, path, "isfile", _pathIsFile, 1);
+  pkModuleAddFunction(vm, path, "isdir", _pathIsDir, 1);
 
   pkReleaseHandle(vm, path);
 }
@@ -310,7 +307,6 @@ void registerModulePath(PKVM* vm) {
 /*****************************************************************************/
 
 static void _fileOpen(PKVM* vm) {
-
   int argc = pkGetArgc(vm);
   if (!pkCheckArgcRange(vm, argc, 1, 2)) return;
 
@@ -325,12 +321,30 @@ static void _fileOpen(PKVM* vm) {
 
     // Check if the mode string is valid, and update the mode value.
     do {
-      if (strcmp(mode_str, "r")  == 0) { mode = FMODE_READ;       break; }
-      if (strcmp(mode_str, "w")  == 0) { mode = FMODE_WRITE;      break; }
-      if (strcmp(mode_str, "a")  == 0) { mode = FMODE_APPEND;     break; }
-      if (strcmp(mode_str, "r+") == 0) { mode = FMODE_READ_EXT;   break; }
-      if (strcmp(mode_str, "w+") == 0) { mode = FMODE_WRITE_EXT;  break; }
-      if (strcmp(mode_str, "a+") == 0) { mode = FMODE_APPEND_EXT; break; }
+      if (strcmp(mode_str, "r") == 0) {
+        mode = FMODE_READ;
+        break;
+      }
+      if (strcmp(mode_str, "w") == 0) {
+        mode = FMODE_WRITE;
+        break;
+      }
+      if (strcmp(mode_str, "a") == 0) {
+        mode = FMODE_APPEND;
+        break;
+      }
+      if (strcmp(mode_str, "r+") == 0) {
+        mode = FMODE_READ_EXT;
+        break;
+      }
+      if (strcmp(mode_str, "w+") == 0) {
+        mode = FMODE_WRITE_EXT;
+        break;
+      }
+      if (strcmp(mode_str, "a+") == 0) {
+        mode = FMODE_APPEND_EXT;
+        break;
+      }
 
       // TODO: (fmt, ...) va_arg for runtime error public api.
       // If we reached here, that means it's an invalid mode string.
@@ -377,7 +391,8 @@ static void _fileRead(PKVM* vm) {
 
 static void _fileWrite(PKVM* vm) {
   File* file;
-  const char* text; uint32_t length;
+  const char* text;
+  uint32_t length;
   if (!pkGetArgInst(vm, 1, OBJ_FILE, (void**)&file)) return;
   if (!pkGetArgString(vm, 2, &text, &length)) return;
 
@@ -404,7 +419,8 @@ static void _fileClose(PKVM* vm) {
   }
 
   if (fclose(file->fp) != 0) {
-    pkSetRuntimeError(vm, "fclose() failed!\n"                     \
+    pkSetRuntimeError(vm,
+                      "fclose() failed!\n"
                       "  at " __FILE__ ":" STRINGIFY(__LINE__) ".");
   }
   file->closed = true;
@@ -413,8 +429,8 @@ static void _fileClose(PKVM* vm) {
 void registerModuleFile(PKVM* vm) {
   PkHandle* file = pkNewModule(vm, "File");
 
-  pkModuleAddFunction(vm, file, "open",  _fileOpen, -1);
-  pkModuleAddFunction(vm, file, "read",  _fileRead,  1);
+  pkModuleAddFunction(vm, file, "open", _fileOpen, -1);
+  pkModuleAddFunction(vm, file, "read", _fileRead, 1);
   pkModuleAddFunction(vm, file, "write", _fileWrite, 2);
   pkModuleAddFunction(vm, file, "close", _fileClose, 1);
 

--- a/cli/modules.h
+++ b/cli/modules.h
@@ -22,13 +22,13 @@ typedef struct {
 // File access mode.
 typedef enum {
 
-  FMODE_READ       = (1 << 0),
-  FMODE_WRITE      = (1 << 1),
-  FMODE_APPEND     = (1 << 2),
+  FMODE_READ = (1 << 0),
+  FMODE_WRITE = (1 << 1),
+  FMODE_APPEND = (1 << 2),
 
-  _FMODE_EXT       = (1 << 3),
-  FMODE_READ_EXT   = (_FMODE_EXT | FMODE_READ),
-  FMODE_WRITE_EXT  = (_FMODE_EXT | FMODE_WRITE),
+  _FMODE_EXT = (1 << 3),
+  FMODE_READ_EXT = (_FMODE_EXT | FMODE_READ),
+  FMODE_WRITE_EXT = (_FMODE_EXT | FMODE_WRITE),
   FMODE_APPEND_EXT = (_FMODE_EXT | FMODE_APPEND),
 } FileAccessMode;
 
@@ -45,9 +45,9 @@ typedef enum {
 typedef struct {
   Obj _super;
 
-  FILE* fp;            // C file poinnter.
-  FileAccessMode mode; // Access mode of the file.
-  bool closed;         // True if the file isn't closed yet.
+  FILE* fp;             // C file poinnter.
+  FileAccessMode mode;  // Access mode of the file.
+  bool closed;          // True if the file isn't closed yet.
 } File;
 
 /*****************************************************************************/

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -6,9 +6,9 @@
 // The REPL (Read Evaluate Print Loop) implementation.
 // https://en.wikipedia.org/wiki/Read-eval-print_loop.
 
-#include "internal.h"
+#include <ctype.h>  // isspace
 
-#include <ctype.h> // isspace
+#include "internal.h"
 #include "utils.h"
 
 // FIXME: use fgetc char by char till reach a new line.
@@ -57,7 +57,6 @@ static inline bool is_str_empty(const char* line) {
 
 // The main loop of the REPL. Will return the exit code.
 int repl(PKVM* vm, const PkCompileOptions* options) {
-
   // Set repl_mode of the user_data.
   VmUserData* user_data = (VmUserData*)pkGetUserData(vm);
   user_data->repl_mode = true;
@@ -79,7 +78,6 @@ int repl(PKVM* vm, const PkCompileOptions* options) {
 
   bool done = false;
   do {
-
     // Print the input listening line.
     if (!need_more_lines) {
       printf(">>> ");
@@ -104,12 +102,12 @@ int repl(PKVM* vm, const PkCompileOptions* options) {
     byteBufferWrite(&lines, '\0');
 
     // Compile the buffer to the module.
-    PkStringPtr source_ptr = { (const char*)lines.data, NULL, NULL };
+    PkStringPtr source_ptr = {(const char*)lines.data, NULL, NULL};
     PkResult result = pkCompileModule(vm, module, source_ptr, options);
 
     if (result == PK_RESULT_UNEXPECTED_EOF) {
       ASSERT(lines.count > 0 && lines.data[lines.count - 1] == '\0', OOPS);
-      lines.count -= 1; // Remove the null byte to append a new string.
+      lines.count -= 1;  // Remove the null byte to append a new string.
       need_more_lines = true;
       continue;
     }
@@ -136,4 +134,3 @@ int repl(PKVM* vm, const PkCompileOptions* options) {
 
   return 0;
 }
-

--- a/cli/thirdparty/.clang-format
+++ b/cli/thirdparty/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/docs/try/main.c
+++ b/docs/try/main.c
@@ -18,13 +18,10 @@ void errorPrint(PKVM* vm, PkErrorType type, const char* file, int line,
   js_errorPrint((int)type, line, message);
 }
 
-void writeFunction(PKVM* vm, const char* text) {
-  js_writeFunction(text);
-}
+void writeFunction(PKVM* vm, const char* text) { js_writeFunction(text); }
 
 EMSCRIPTEN_KEEPALIVE
 int runSource(const char* source) {
-
   PkConfiguration config = pkNewConfiguration();
   config.error_fn = errorPrint;
   config.write_fn = writeFunction;
@@ -33,8 +30,8 @@ int runSource(const char* source) {
 
   PKVM* vm = pkNewVM(&config);
 
-  PkStringPtr src = { source, NULL, NULL };
-  PkStringPtr module = { "$(TRY)", NULL, NULL };
+  PkStringPtr src = {source, NULL, NULL};
+  PkStringPtr module = {"$(TRY)", NULL, NULL};
   PkResult result = pkInterpretSource(vm, src, module, NULL);
 
   pkFreeVM(vm);

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -29,7 +29,7 @@ extern "C" {
 // String representation of the version.
 #define PK_VERSION_STRING "0.1.0"
 
-// Pocketlang visibility macros. define PK_DLL for using pocketlang as a 
+// Pocketlang visibility macros. define PK_DLL for using pocketlang as a
 // shared library and define PK_COMPILE to export symbols when compiling the
 // pocketlang it self as a shared library.
 
@@ -37,7 +37,7 @@ extern "C" {
   #define _PK_EXPORT __declspec(dllexport)
   #define _PK_IMPORT __declspec(dllimport)
 #elif defined(__GNUC__)
-  #define _PK_EXPORT __attribute__((visibility ("default")))
+  #define _PK_EXPORT __attribute__((visibility("default")))
   #define _PK_IMPORT
 #else
   #define _PK_EXPORT
@@ -100,15 +100,15 @@ typedef struct PkCompileOptions PkCompileOptions;
 // Type of the error message that pocketlang will provide with the pkErrorFn
 // callback.
 typedef enum {
-  PK_ERROR_COMPILE = 0, // Compile time errors.
-  PK_ERROR_RUNTIME,     // Runtime error message.
-  PK_ERROR_STACKTRACE,  // One entry of a runtime error stack.
+  PK_ERROR_COMPILE = 0,  // Compile time errors.
+  PK_ERROR_RUNTIME,      // Runtime error message.
+  PK_ERROR_STACKTRACE,   // One entry of a runtime error stack.
 } PkErrorType;
 
 // Result that pocketlang will return after a compilation or running a script
 // or a function or evaluating an expression.
 typedef enum {
-  PK_RESULT_SUCCESS = 0,    // Successfully finished the execution.
+  PK_RESULT_SUCCESS = 0,  // Successfully finished the execution.
 
   // Unexpected EOF while compiling the source. This is another compile time
   // error that will ONLY be returned if we're compiling with the REPL mode set
@@ -144,60 +144,59 @@ typedef void* (*pkReallocFn)(void* memory, size_t new_size, void* user_data);
 // Error callback function pointer. For runtime error it'll call first with
 // PK_ERROR_RUNTIME followed by multiple callbacks with PK_ERROR_STACKTRACE.
 // The error messages should be written to stderr.
-typedef void (*pkErrorFn) (PKVM* vm, PkErrorType type,
-                           const char* file, int line,
-                           const char* message);
+typedef void (*pkErrorFn)(PKVM* vm, PkErrorType type, const char* file,
+                          int line, const char* message);
 
 // A function callback to write [text] to stdout.
-typedef void (*pkWriteFn) (PKVM* vm, const char* text);
+typedef void (*pkWriteFn)(PKVM* vm, const char* text);
 
 // A function callback to read a line from stdin. The returned string shouldn't
 // contain a line ending (\n or \r\n).
-typedef PkStringPtr (*pkReadFn) (PKVM* vm);
+typedef PkStringPtr (*pkReadFn)(PKVM* vm);
 
 // A function callback, that'll be called when a native instance (wrapper) is
 // freed by by the garbage collector, to indicate that pocketlang is done with
 // the native instance.
-typedef void (*pkInstFreeFn) (PKVM* vm, void* instance, uint32_t id);
+typedef void (*pkInstFreeFn)(PKVM* vm, void* instance, uint32_t id);
 
 // A function callback to get the name of the native instance from pocketlang,
 // using it's [id]. The returned string won't be copied by pocketlang so it's
 // expected to be alived since the instance is alive and recomended to return
 // a C literal string.
-typedef const char* (*pkInstNameFn) (uint32_t id);
+typedef const char* (*pkInstNameFn)(uint32_t id);
 
 // A get arribute callback, called by pocket VM when trying to get an attribute
 // from a native type. to return the value of the attribute use 'pkReturn...()'
 // functions. DON'T set an error to the VM if the attribute not exists. Example
 // if the '.as_string' attribute doesn't exists, pocket VM will use a default
 // to string value.
-typedef void (*pkInstGetAttribFn) (PKVM* vm, void* instance, uint32_t id,
-                                   PkStringPtr attrib);
+typedef void (*pkInstGetAttribFn)(PKVM* vm, void* instance, uint32_t id,
+                                  PkStringPtr attrib);
 
 // Use pkGetArg...(vm, 0, ptr) function to get the value of the attribute
 // and use 0 as the argument index, using any other arg index value cause UB.
-// 
+//
 // If the attribute dones't exists DON'T set an error, instead return false.
 // Pocket VM will handle it, On success update the native instance and return
 // true. And DON'T ever use 'pkReturn...()' in the attribute setter It's is a
 // void return function.
-typedef bool (*pkInstSetAttribFn) (PKVM* vm, void* instance, uint32_t id,
-                                   PkStringPtr attrib);
+typedef bool (*pkInstSetAttribFn)(PKVM* vm, void* instance, uint32_t id,
+                                  PkStringPtr attrib);
 
 // A function callback symbol for clean/free the pkStringResult.
-typedef void (*pkResultDoneFn) (PKVM* vm, PkStringPtr result);
+typedef void (*pkResultDoneFn)(PKVM* vm, PkStringPtr result);
 
 // A function callback to resolve the import script name from the [from] path
 // to an absolute (or relative to the cwd). This is required to solve same
 // script imported with different relative path. Set the string attribute to
 // NULL to indicate if it's failed to resolve.
-typedef PkStringPtr (*pkResolvePathFn) (PKVM* vm, const char* from,
-                                        const char* path);
+typedef PkStringPtr (*pkResolvePathFn)(PKVM* vm, const char* from,
+                                       const char* path);
 
 // Load and return the script. Called by the compiler to fetch initial source
 // code and source for import statements. Set the string attribute to NULL
 // to indicate if it's failed to load the script.
-typedef PkStringPtr (*pkLoadScriptFn) (PKVM* vm, const char* path);
+typedef PkStringPtr (*pkLoadScriptFn)(PKVM* vm, const char* path);
 
 /*****************************************************************************/
 /* POCKETLANG PUBLIC API                                                     */
@@ -240,14 +239,14 @@ PK_PUBLIC PkVar pkGetHandleValue(const PkHandle* handle);
 PK_PUBLIC void pkReleaseHandle(PKVM* vm, PkHandle* handle);
 
 // Add a global [value] to the given module.
-PK_PUBLIC void pkModuleAddGlobal(PKVM* vm, PkHandle* module,
-                                 const char* name, PkHandle* value);
+PK_PUBLIC void pkModuleAddGlobal(PKVM* vm, PkHandle* module, const char* name,
+                                 PkHandle* value);
 
 // Add a native function to the given module. If [arity] is -1 that means
 // The function has variadic parameters and use pkGetArgc() to get the argc.
 PK_PUBLIC void pkModuleAddFunction(PKVM* vm, PkHandle* module,
-                                   const char* name,
-                                   pkNativeFn fptr, int arity);
+                                   const char* name, pkNativeFn fptr,
+                                   int arity);
 
 // Returns the function from the [module] as a handle, if not found it'll
 // return NULL.
@@ -264,8 +263,7 @@ PK_PUBLIC PkResult pkCompileModule(PKVM* vm, PkHandle* module,
 // and path 'on_done' will be called to clean the string if it's not NULL.
 // Set the compiler options with the the [options] argument or it can be set to
 // NULL for default options.
-PK_PUBLIC PkResult pkInterpretSource(PKVM* vm,
-                                     PkStringPtr source,
+PK_PUBLIC PkResult pkInterpretSource(PKVM* vm, PkStringPtr source,
                                      PkStringPtr path,
                                      const PkCompileOptions* options);
 
@@ -274,8 +272,8 @@ PK_PUBLIC PkResult pkInterpretSource(PKVM* vm,
 // result (success or failure) if you need the yielded or returned value use
 // the pkFiberGetReturnValue() function, and use pkFiberIsDone() function to
 // check if the fiber can be resumed with pkFiberResume() function.
-PK_PUBLIC PkResult pkRunFiber(PKVM* vm, PkHandle* fiber,
-                              int argc, PkHandle** argv);
+PK_PUBLIC PkResult pkRunFiber(PKVM* vm, PkHandle* fiber, int argc,
+                              PkHandle** argv);
 
 // Resume a yielded fiber with an optional [value]. (could be set to NULL)
 // It'll returns it's run status result (success or failure) if you need the
@@ -290,9 +288,9 @@ PK_PUBLIC PkResult pkResumeFiber(PKVM* vm, PkHandle* fiber, PkVar value);
 // pocket VM. With a on_done() callback to clean it when the pocket VM is done
 // with the string.
 struct PkStringPtr {
-  const char* string;     //< The string result.
-  pkResultDoneFn on_done; //< Called once vm done with the string.
-  void* user_data;        //< User related data.
+  const char* string;      //< The string result.
+  pkResultDoneFn on_done;  //< Called once vm done with the string.
+  void* user_data;         //< User related data.
 
   // These values are provided by the pocket VM to the host application, you're
   // not expected to set this when provideing string to the pocket VM.
@@ -301,7 +299,6 @@ struct PkStringPtr {
 };
 
 struct PkConfiguration {
-
   // The callback used to allocate, reallocate, and free. If the function
   // pointer is NULL it defaults to the VM's realloc(), free() wrappers.
   pkReallocFn realloc_fn;
@@ -325,7 +322,6 @@ struct PkConfiguration {
 // The options to configure the compilation provided by the command line
 // arguments (or other ways the host application provides).
 struct PkCompileOptions {
-
   // Compile debug version of the source.
   bool debug;
 
@@ -334,7 +330,6 @@ struct PkCompileOptions {
   // [expression] should also be true otherwise it's incompatible, (will fail
   // an assertion).
   bool repl_mode;
-
 };
 
 /*****************************************************************************/
@@ -345,7 +340,7 @@ struct PkCompileOptions {
 PK_PUBLIC void pkSetRuntimeError(PKVM* vm, const char* message);
 
 // TODO: Set a runtime error to VM, with the formated string.
-//PK_PUBLIC void pkSetRuntimeErrorFmt(PKVM* vm, const char* fmt, ...);
+// PK_PUBLIC void pkSetRuntimeErrorFmt(PKVM* vm, const char* fmt, ...);
 
 // Return the type of the [value] this will help to get the type of the
 // variable that was extracted from pkGetArg() earlier.
@@ -370,14 +365,14 @@ PK_PUBLIC PkVar pkGetArg(const PKVM* vm, int arg);
 // stack as a type. They will first validate the argument's type and set a
 // runtime error if it's not and return false. Otherwise it'll set the [value]
 // with the extracted value.
-// 
+//
 // NOTE: The arguments are 1 based (to get the first argument use 1 not 0).
 //       Only use arg index 0 to get the value of attribute setter call.
 
 PK_PUBLIC bool pkGetArgBool(PKVM* vm, int arg, bool* value);
 PK_PUBLIC bool pkGetArgNumber(PKVM* vm, int arg, double* value);
-PK_PUBLIC bool pkGetArgString(PKVM* vm, int arg,
-                              const char** value, uint32_t* length);
+PK_PUBLIC bool pkGetArgString(PKVM* vm, int arg, const char** value,
+                              uint32_t* length);
 PK_PUBLIC bool pkGetArgInst(PKVM* vm, int arg, uint32_t id, void** value);
 PK_PUBLIC bool pkGetArgValue(PKVM* vm, int arg, PkVarType type, PkVar* value);
 
@@ -437,12 +432,12 @@ PK_PUBLIC PkHandle* pkNewInstNative(PKVM* vm, void* data, uint32_t id);
 // in that buffer, this will prevent us from invoking an allocation call for
 // each time we want to pass a primitive type.
 
-//PK_PUBLIC PkVar pkPushNull(PKVM* vm);
-//PK_PUBLIC PkVar pkPushBool(PKVM* vm, bool value);
-//PK_PUBLIC PkVar pkPushNumber(PKVM* vm, double value);
+// PK_PUBLIC PkVar pkPushNull(PKVM* vm);
+// PK_PUBLIC PkVar pkPushBool(PKVM* vm, bool value);
+// PK_PUBLIC PkVar pkPushNumber(PKVM* vm, double value);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
-#endif // POCKETLANG_H
+#endif  // POCKETLANG_H

--- a/src/pk_buffers.h
+++ b/src/pk_buffers.h
@@ -17,35 +17,35 @@
 // internal data array will be reallocate to a capacity of 'GROW_FACTOR' times
 // it's last capacity.
 
-#define DECLARE_BUFFER(m_name, m_type)                                        \
-  typedef struct {                                                            \
-    m_type* data;                                                             \
-    uint32_t count;                                                           \
-    uint32_t capacity;                                                        \
-  } pk##m_name##Buffer;                                                       \
-                                                                              \
-  /* Initialize a new buffer int instance. */                                 \
-  void pk##m_name##BufferInit(pk##m_name##Buffer* self);                      \
-                                                                              \
-  /* Clears the allocated elements from the VM's realloc function. */         \
-  void pk##m_name##BufferClear(pk##m_name##Buffer* self, PKVM* vm);           \
-                                                                              \
-  /* Ensure the capacity is greater than [size], if not resize. */            \
-  void pk##m_name##BufferReserve(pk##m_name##Buffer* self, PKVM* vm,          \
-                                 size_t size);                                \
-                                                                              \
-  /* Fill the buffer at the end of it with provided data if the capacity */   \
-  /* isn't enough using VM's realloc function. */                             \
-  void pk##m_name##BufferFill(pk##m_name##Buffer* self, PKVM* vm,             \
-                              m_type data, int count);                        \
-                                                                              \
-  /* Write to the buffer with provided data at the end of the buffer.*/       \
-  void pk##m_name##BufferWrite(pk##m_name##Buffer* self,                      \
-                               PKVM* vm, m_type data);                        \
-                                                                              \
-  /* Concatenate the contents of another buffer at the end of this buffer.*/  \
-  void pk##m_name##BufferConcat(pk##m_name##Buffer* self, PKVM* vm,           \
-                                pk##m_name##Buffer* other);                   \
+#define DECLARE_BUFFER(m_name, m_type)                                       \
+  typedef struct {                                                           \
+    m_type* data;                                                            \
+    uint32_t count;                                                          \
+    uint32_t capacity;                                                       \
+  } pk##m_name##Buffer;                                                      \
+                                                                             \
+  /* Initialize a new buffer int instance. */                                \
+  void pk##m_name##BufferInit(pk##m_name##Buffer* self);                     \
+                                                                             \
+  /* Clears the allocated elements from the VM's realloc function. */        \
+  void pk##m_name##BufferClear(pk##m_name##Buffer* self, PKVM* vm);          \
+                                                                             \
+  /* Ensure the capacity is greater than [size], if not resize. */           \
+  void pk##m_name##BufferReserve(pk##m_name##Buffer* self, PKVM* vm,         \
+                                 size_t size);                               \
+                                                                             \
+  /* Fill the buffer at the end of it with provided data if the capacity */  \
+  /* isn't enough using VM's realloc function. */                            \
+  void pk##m_name##BufferFill(pk##m_name##Buffer* self, PKVM* vm,            \
+                              m_type data, int count);                       \
+                                                                             \
+  /* Write to the buffer with provided data at the end of the buffer.*/      \
+  void pk##m_name##BufferWrite(pk##m_name##Buffer* self, PKVM* vm,           \
+                               m_type data);                                 \
+                                                                             \
+  /* Concatenate the contents of another buffer at the end of this buffer.*/ \
+  void pk##m_name##BufferConcat(pk##m_name##Buffer* self, PKVM* vm,          \
+                                pk##m_name##Buffer* other);
 
 // The buffer "template" implementation of different types.
 #define DEFINE_BUFFER(m_name, m_type)                                         \
@@ -55,8 +55,7 @@
     self->capacity = 0;                                                       \
   }                                                                           \
                                                                               \
-  void pk##m_name##BufferClear(pk##m_name##Buffer* self,                      \
-              PKVM* vm) {                                                     \
+  void pk##m_name##BufferClear(pk##m_name##Buffer* self, PKVM* vm) {          \
     vmRealloc(vm, self->data, self->capacity * sizeof(m_type), 0);            \
     self->data = NULL;                                                        \
     self->count = 0;                                                          \
@@ -68,15 +67,15 @@
     if (self->capacity < size) {                                              \
       int capacity = utilPowerOf2Ceil((int)size);                             \
       if (capacity < MIN_CAPACITY) capacity = MIN_CAPACITY;                   \
-      self->data = (m_type*)vmRealloc(vm, self->data,                         \
-        self->capacity * sizeof(m_type), capacity * sizeof(m_type));          \
+      self->data =                                                            \
+          (m_type*)vmRealloc(vm, self->data, self->capacity * sizeof(m_type), \
+                             capacity * sizeof(m_type));                      \
       self->capacity = capacity;                                              \
     }                                                                         \
   }                                                                           \
                                                                               \
   void pk##m_name##BufferFill(pk##m_name##Buffer* self, PKVM* vm,             \
                               m_type data, int count) {                       \
-                                                                              \
     pk##m_name##BufferReserve(self, vm, self->count + count);                 \
                                                                               \
     for (int i = 0; i < count; i++) {                                         \
@@ -84,8 +83,8 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  void pk##m_name##BufferWrite(pk##m_name##Buffer* self,                      \
-                               PKVM* vm, m_type data) {                       \
+  void pk##m_name##BufferWrite(pk##m_name##Buffer* self, PKVM* vm,            \
+                               m_type data) {                                 \
     pk##m_name##BufferFill(self, vm, data, 1);                                \
   }                                                                           \
                                                                               \
@@ -93,10 +92,9 @@
                                 pk##m_name##Buffer* other) {                  \
     pk##m_name##BufferReserve(self, vm, self->count + other->count);          \
                                                                               \
-    memcpy(self->data + self->count,                                          \
-           other->data,                                                       \
+    memcpy(self->data + self->count, other->data,                             \
            other->count * sizeof(m_type));                                    \
     self->count += other->count;                                              \
   }
 
-#endif // BUFFERS_TEMPLATE_H
+#endif  // BUFFERS_TEMPLATE_H

--- a/src/pk_compiler.c
+++ b/src/pk_compiler.c
@@ -5,11 +5,11 @@
 
 #include "pk_compiler.h"
 
-#include "pk_core.h"
 #include "pk_buffers.h"
+#include "pk_core.h"
+#include "pk_debug.h"
 #include "pk_utils.h"
 #include "pk_vm.h"
-#include "pk_debug.h"
 
 // The maximum number of variables (or global if compiling top level script)
 // to lookup from the compiling context. Also it's limited by it's opcode
@@ -53,90 +53,90 @@ typedef enum {
   TK_LINE,
 
   // symbols
-  TK_DOT,        // .
-  TK_DOTDOT,     // ..
-  TK_COMMA,      // ,
-  TK_COLLON,     // :
-  TK_SEMICOLLON, // ;
-  TK_HASH,       // #
-  TK_LPARAN,     // (
-  TK_RPARAN,     // )
-  TK_LBRACKET,   // [
-  TK_RBRACKET,   // ]
-  TK_LBRACE,     // {
-  TK_RBRACE,     // }
-  TK_PERCENT,    // %
+  TK_DOT,         // .
+  TK_DOTDOT,      // ..
+  TK_COMMA,       // ,
+  TK_COLLON,      // :
+  TK_SEMICOLLON,  // ;
+  TK_HASH,        // #
+  TK_LPARAN,      // (
+  TK_RPARAN,      // )
+  TK_LBRACKET,    // [
+  TK_RBRACKET,    // ]
+  TK_LBRACE,      // {
+  TK_RBRACE,      // }
+  TK_PERCENT,     // %
 
-  TK_TILD,       // ~
-  TK_AMP,        // &
-  TK_PIPE,       // |
-  TK_CARET,      // ^
-  TK_ARROW,      // ->
+  TK_TILD,   // ~
+  TK_AMP,    // &
+  TK_PIPE,   // |
+  TK_CARET,  // ^
+  TK_ARROW,  // ->
 
-  TK_PLUS,       // +
-  TK_MINUS,      // -
-  TK_STAR,       // *
-  TK_FSLASH,     // /
-  TK_BSLASH,     // \.
-  TK_EQ,         // =
-  TK_GT,         // >
-  TK_LT,         // <
+  TK_PLUS,    // +
+  TK_MINUS,   // -
+  TK_STAR,    // *
+  TK_FSLASH,  // /
+  TK_BSLASH,  // \.
+  TK_EQ,      // =
+  TK_GT,      // >
+  TK_LT,      // <
 
-  TK_EQEQ,       // ==
-  TK_NOTEQ,      // !=
-  TK_GTEQ,       // >=
-  TK_LTEQ,       // <=
+  TK_EQEQ,   // ==
+  TK_NOTEQ,  // !=
+  TK_GTEQ,   // >=
+  TK_LTEQ,   // <=
 
-  TK_PLUSEQ,     // +=
-  TK_MINUSEQ,    // -=
-  TK_STAREQ,     // *=
-  TK_DIVEQ,      // /=
-  TK_MODEQ,      // %=
+  TK_PLUSEQ,   // +=
+  TK_MINUSEQ,  // -=
+  TK_STAREQ,   // *=
+  TK_DIVEQ,    // /=
+  TK_MODEQ,    // %=
 
-  TK_ANDEQ,      // &=
-  TK_OREQ,       // |=
-  TK_XOREQ,      // ^=
+  TK_ANDEQ,  // &=
+  TK_OREQ,   // |=
+  TK_XOREQ,  // ^=
 
-  TK_SRIGHT,     // >>
-  TK_SLEFT,      // <<
+  TK_SRIGHT,  // >>
+  TK_SLEFT,   // <<
 
-  TK_SRIGHTEQ,   // >>=
-  TK_SLEFTEQ,    // <<=
+  TK_SRIGHTEQ,  // >>=
+  TK_SLEFTEQ,   // <<=
 
   // Keywords.
-  TK_MODULE,     // module
-  TK_CLASS,      // class
-  TK_FROM,       // from
-  TK_IMPORT,     // import
-  TK_AS,         // as
-  TK_DEF,        // def
-  TK_NATIVE,     // native (C function declaration)
-  TK_FUNC,       // func (literal function)
-  TK_END,        // end
+  TK_MODULE,  // module
+  TK_CLASS,   // class
+  TK_FROM,    // from
+  TK_IMPORT,  // import
+  TK_AS,      // as
+  TK_DEF,     // def
+  TK_NATIVE,  // native (C function declaration)
+  TK_FUNC,    // func (literal function)
+  TK_END,     // end
 
-  TK_NULL,       // null
-  TK_IN,         // in
-  TK_AND,        // and
-  TK_OR,         // or
-  TK_NOT,        // not / !
-  TK_TRUE,       // true
-  TK_FALSE,      // false
+  TK_NULL,   // null
+  TK_IN,     // in
+  TK_AND,    // and
+  TK_OR,     // or
+  TK_NOT,    // not / !
+  TK_TRUE,   // true
+  TK_FALSE,  // false
 
-  TK_DO,         // do
-  TK_THEN,       // then
-  TK_WHILE,      // while
-  TK_FOR,        // for
-  TK_IF,         // if
-  TK_ELSIF,      // elsif
-  TK_ELSE,       // else
-  TK_BREAK,      // break
-  TK_CONTINUE,   // continue
-  TK_RETURN,     // return
+  TK_DO,        // do
+  TK_THEN,      // then
+  TK_WHILE,     // while
+  TK_FOR,       // for
+  TK_IF,        // if
+  TK_ELSIF,     // elsif
+  TK_ELSE,      // else
+  TK_BREAK,     // break
+  TK_CONTINUE,  // continue
+  TK_RETURN,    // return
 
-  TK_NAME,       // identifier
+  TK_NAME,  // identifier
 
-  TK_NUMBER,     // number literal
-  TK_STRING,     // string literal
+  TK_NUMBER,  // number literal
+  TK_STRING,  // string literal
 
   /* String interpolation (reference wren-lang)
    * but it doesn't support recursive ex: "a \(b + "\(c)")"
@@ -147,17 +147,17 @@ typedef enum {
    *   TK_STR_INTERP  " c "
    *   TK_NAME        d
    *   TK_STRING     " e" */
-   // TK_STR_INTERP, //< not yet.
+  // TK_STR_INTERP, //< not yet.
 
 } TokenType;
 
 typedef struct {
   TokenType type;
 
-  const char* start; //< Begining of the token in the source.
-  int length;        //< Number of chars of the token.
-  int line;          //< Line number of the token (1 based).
-  Var value;         //< Literal value of the token.
+  const char* start;  //< Begining of the token in the source.
+  int length;         //< Number of chars of the token.
+  int line;           //< Line number of the token (1 based).
+  Var value;          //< Literal value of the token.
 } Token;
 
 typedef struct {
@@ -168,34 +168,34 @@ typedef struct {
 
 // List of keywords mapped into their identifiers.
 static _Keyword _keywords[] = {
-  { "module",   6, TK_MODULE   },
-  { "class",    5, TK_CLASS    },
-  { "from",     4, TK_FROM     },
-  { "import",   6, TK_IMPORT   },
-  { "as",       2, TK_AS       },
-  { "def",      3, TK_DEF      },
-  { "native",   6, TK_NATIVE   },
-  { "func",     4, TK_FUNC     },
-  { "end",      3, TK_END      },
-  { "null",     4, TK_NULL     },
-  { "in",       2, TK_IN       },
-  { "and",      3, TK_AND      },
-  { "or",       2, TK_OR       },
-  { "not",      3, TK_NOT      },
-  { "true",     4, TK_TRUE     },
-  { "false",    5, TK_FALSE    },
-  { "do",       2, TK_DO       },
-  { "then",     4, TK_THEN     },
-  { "while",    5, TK_WHILE    },
-  { "for",      3, TK_FOR      },
-  { "if",       2, TK_IF       },
-  { "elsif",    5, TK_ELSIF    },
-  { "else",     4, TK_ELSE     },
-  { "break",    5, TK_BREAK    },
-  { "continue", 8, TK_CONTINUE },
-  { "return",   6, TK_RETURN   },
+    {"module", 6, TK_MODULE},
+    {"class", 5, TK_CLASS},
+    {"from", 4, TK_FROM},
+    {"import", 6, TK_IMPORT},
+    {"as", 2, TK_AS},
+    {"def", 3, TK_DEF},
+    {"native", 6, TK_NATIVE},
+    {"func", 4, TK_FUNC},
+    {"end", 3, TK_END},
+    {"null", 4, TK_NULL},
+    {"in", 2, TK_IN},
+    {"and", 3, TK_AND},
+    {"or", 2, TK_OR},
+    {"not", 3, TK_NOT},
+    {"true", 4, TK_TRUE},
+    {"false", 5, TK_FALSE},
+    {"do", 2, TK_DO},
+    {"then", 4, TK_THEN},
+    {"while", 5, TK_WHILE},
+    {"for", 3, TK_FOR},
+    {"if", 2, TK_IF},
+    {"elsif", 5, TK_ELSIF},
+    {"else", 4, TK_ELSE},
+    {"break", 5, TK_BREAK},
+    {"continue", 8, TK_CONTINUE},
+    {"return", 6, TK_RETURN},
 
-  { NULL,       0, (TokenType)(0) }, // Sentinel to mark the end of the array
+    {NULL, 0, (TokenType)(0)},  // Sentinel to mark the end of the array
 };
 
 /*****************************************************************************/
@@ -210,23 +210,23 @@ static _Keyword _keywords[] = {
 typedef enum {
   PREC_NONE,
   PREC_LOWEST,
-  PREC_LOGICAL_OR,    // or
-  PREC_LOGICAL_AND,   // and
-  PREC_EQUALITY,      // == !=
-  PREC_TEST,          // in is
-  PREC_COMPARISION,   // < > <= >=
-  PREC_BITWISE_OR,    // |
-  PREC_BITWISE_XOR,   // ^
-  PREC_BITWISE_AND,   // &
-  PREC_BITWISE_SHIFT, // << >>
-  PREC_RANGE,         // ..
-  PREC_TERM,          // + -
-  PREC_FACTOR,        // * / %
-  PREC_UNARY,         // - ! ~ not
-  PREC_CHAIN_CALL,    // ->
-  PREC_CALL,          // ()
-  PREC_SUBSCRIPT,     // []
-  PREC_ATTRIB,        // .index
+  PREC_LOGICAL_OR,     // or
+  PREC_LOGICAL_AND,    // and
+  PREC_EQUALITY,       // == !=
+  PREC_TEST,           // in is
+  PREC_COMPARISION,    // < > <= >=
+  PREC_BITWISE_OR,     // |
+  PREC_BITWISE_XOR,    // ^
+  PREC_BITWISE_AND,    // &
+  PREC_BITWISE_SHIFT,  // << >>
+  PREC_RANGE,          // ..
+  PREC_TERM,           // + -
+  PREC_FACTOR,         // * / %
+  PREC_UNARY,          // - ! ~ not
+  PREC_CHAIN_CALL,     // ->
+  PREC_CALL,           // ()
+  PREC_SUBSCRIPT,      // []
+  PREC_ATTRIB,         // .index
   PREC_PRIMARY,
 } Precedence;
 
@@ -239,26 +239,25 @@ typedef struct {
 } GrammarRule;
 
 typedef enum {
-  DEPTH_SCRIPT = -2, //< Only used for script body function's depth.
-  DEPTH_GLOBAL = -1, //< Global variables.
-  DEPTH_LOCAL,       //< Local scope. Increase with inner scope.
+  DEPTH_SCRIPT = -2,  //< Only used for script body function's depth.
+  DEPTH_GLOBAL = -1,  //< Global variables.
+  DEPTH_LOCAL,        //< Local scope. Increase with inner scope.
 } Depth;
 
 typedef enum {
-  FN_NATIVE,    //< Native C function.
-  FN_SCRIPT,    //< Script level functions defined with 'def'.
-  FN_LITERAL,   //< Literal functions defined with 'function(){...}'
+  FN_NATIVE,   //< Native C function.
+  FN_SCRIPT,   //< Script level functions defined with 'def'.
+  FN_LITERAL,  //< Literal functions defined with 'function(){...}'
 } FuncType;
 
 typedef struct {
-  const char* name; //< Directly points into the source string.
-  uint32_t length;  //< Length of the name.
-  int depth;        //< The depth the local is defined in.
-  int line;         //< The line variable declared for debugging.
+  const char* name;  //< Directly points into the source string.
+  uint32_t length;   //< Length of the name.
+  int depth;         //< The depth the local is defined in.
+  int line;          //< The line variable declared for debugging.
 } Local;
 
 typedef struct sLoop {
-
   // Index of the loop's start instruction where the execution will jump
   // back to once it reach the loop end or continue used.
   int start;
@@ -284,7 +283,6 @@ typedef struct sLoop {
 // To keep track of names used but not defined yet. This is only used for
 // functions, because variables can't be accessed before it ever defined.
 typedef struct sForwardName {
-
   // Index of the short instruction that has the value of the name (in the
   // names buffer of the script).
   int instruction;
@@ -302,7 +300,6 @@ typedef struct sForwardName {
 } ForwardName;
 
 typedef struct sFunc {
-
   // Scope of the function. -2 for script body, -1 for top level function and
   // literal functions will have the scope where it declared.
   int depth;
@@ -323,28 +320,27 @@ typedef struct sFunc {
 #define _FN (compiler->func->ptr->fn)
 
 struct Compiler {
-
   PKVM* vm;
   Compiler* next_compiler;
 
   // Variables related to parsing.
-  const char* source;       //< Currently compiled source (Weak pointer).
-  const char* token_start;  //< Start of the currently parsed token.
-  const char* current_char; //< Current char position in the source.
-  int current_line;         //< Line number of the current char.
-  Token previous, current, next; //< Currently parsed tokens.
+  const char* source;             //< Currently compiled source (Weak pointer).
+  const char* token_start;        //< Start of the currently parsed token.
+  const char* current_char;       //< Current char position in the source.
+  int current_line;               //< Line number of the current char.
+  Token previous, current, next;  //< Currently parsed tokens.
 
-  bool has_errors;          //< True if any syntex error occurred at.
-  bool need_more_lines;     //< True if we need more lines in REPL mode.
+  bool has_errors;       //< True if any syntex error occurred at.
+  bool need_more_lines;  //< True if we need more lines in REPL mode.
 
-  const PkCompileOptions* options; //< To configure the compilation.
+  const PkCompileOptions* options;  //< To configure the compilation.
 
   // Current depth the compiler in (-1 means top level) 0 means function
   // level and > 0 is inner scope.
   int scope_depth;
 
-  Local locals[MAX_VARIABLES]; //< Variables in the current context.
-  int local_count; //< Number of locals in [locals].
+  Local locals[MAX_VARIABLES];  //< Variables in the current context.
+  int local_count;              //< Number of locals in [locals].
 
   int stack_size;  //< Current size including locals ind temps.
 
@@ -387,9 +383,9 @@ typedef struct {
 } OpInfo;
 
 static OpInfo opcode_info[] = {
-  #define OPCODE(name, params, stack) { params, stack },
-  #include "pk_opcodes.h"
-  #undef OPCODE
+#define OPCODE(name, params, stack) {params, stack},
+#include "pk_opcodes.h"
+#undef OPCODE
 };
 
 /*****************************************************************************/
@@ -399,7 +395,6 @@ static OpInfo opcode_info[] = {
 // Internal error report function of the parseError() function.
 static void reportError(Compiler* compiler, const char* file, int line,
                         const char* fmt, va_list args) {
-
   // On REPL mode only the first error is reported.
   if (compiler->options && compiler->options->repl_mode &&
       compiler->has_errors) {
@@ -439,7 +434,6 @@ static void lexError(Compiler* compiler, const char* fmt, ...) {
 // Error caused when parsing. The associated token assumed to be last consumed
 // which is [compiler->previous].
 static void parseError(Compiler* compiler, const char* fmt, ...) {
-
   Token* token = &compiler->previous;
 
   // Lex errors would repored earlier by lexError and lexed a TK_ERROR token.
@@ -496,12 +490,24 @@ static void eatString(Compiler* compiler, bool single_quote) {
 
     if (c == '\\') {
       switch (eatChar(compiler)) {
-        case '"':  pkByteBufferWrite(&buff, compiler->vm, '"'); break;
-        case '\'': pkByteBufferWrite(&buff, compiler->vm, '\''); break;
-        case '\\': pkByteBufferWrite(&buff, compiler->vm, '\\'); break;
-        case 'n':  pkByteBufferWrite(&buff, compiler->vm, '\n'); break;
-        case 'r':  pkByteBufferWrite(&buff, compiler->vm, '\r'); break;
-        case 't':  pkByteBufferWrite(&buff, compiler->vm, '\t'); break;
+        case '"':
+          pkByteBufferWrite(&buff, compiler->vm, '"');
+          break;
+        case '\'':
+          pkByteBufferWrite(&buff, compiler->vm, '\'');
+          break;
+        case '\\':
+          pkByteBufferWrite(&buff, compiler->vm, '\\');
+          break;
+        case 'n':
+          pkByteBufferWrite(&buff, compiler->vm, '\n');
+          break;
+        case 'r':
+          pkByteBufferWrite(&buff, compiler->vm, '\r');
+          break;
+        case 't':
+          pkByteBufferWrite(&buff, compiler->vm, '\t');
+          break;
 
         default:
           lexError(compiler, "Error: invalid escape character");
@@ -514,7 +520,7 @@ static void eatString(Compiler* compiler, bool single_quote) {
 
   // '\0' will be added by varNewSring();
   Var string = VAR_OBJ(newStringLength(compiler->vm, (const char*)buff.data,
-                       (uint32_t)buff.count));
+                                       (uint32_t)buff.count));
 
   pkByteBufferClear(&buff, compiler->vm);
 
@@ -522,9 +528,7 @@ static void eatString(Compiler* compiler, bool single_quote) {
 }
 
 // Returns the current char of the compiler on.
-static char peekChar(Compiler* compiler) {
-  return *compiler->current_char;
-}
+static char peekChar(Compiler* compiler) { return *compiler->current_char; }
 
 // Returns the next char of the compiler on.
 static char peekNextChar(Compiler* compiler) {
@@ -542,7 +546,6 @@ static char eatChar(Compiler* compiler) {
 
 // Complete lexing an identifier name.
 static void eatName(Compiler* compiler) {
-
   char c = peekChar(compiler);
   while (utilIsName(c) || utilIsDigit(c)) {
     eatChar(compiler);
@@ -556,7 +559,7 @@ static void eatName(Compiler* compiler) {
   int length = (int)(compiler->current_char - name_start);
   for (int i = 0; _keywords[i].identifier != NULL; i++) {
     if (_keywords[i].length == length &&
-      strncmp(name_start, _keywords[i].identifier, length) == 0) {
+        strncmp(name_start, _keywords[i].identifier, length) == 0) {
       type = _keywords[i].tk_type;
       break;
     }
@@ -567,19 +570,17 @@ static void eatName(Compiler* compiler) {
 
 // Complete lexing a number literal.
 static void eatNumber(Compiler* compiler) {
-
-#define IS_HEX_CHAR(c)            \
-  (('0' <= (c) && (c) <= '9')  || \
-   ('a' <= (c) && (c) <= 'f'))
+#define IS_HEX_CHAR(c) \
+  (('0' <= (c) && (c) <= '9') || ('a' <= (c) && (c) <= 'f'))
 
 #define IS_BIN_CHAR(c) (((c) == '0') || ((c) == '1'))
 
-  Var value = VAR_NULL; // The number value.
+  Var value = VAR_NULL;  // The number value.
   char c = *compiler->token_start;
 
   // Binary literal.
   if (c == '0' && peekChar(compiler) == 'b') {
-    eatChar(compiler); // Consume '0b'
+    eatChar(compiler);  // Consume '0b'
 
     uint64_t bin = 0;
     c = peekChar(compiler);
@@ -595,7 +596,7 @@ static void eatNumber(Compiler* compiler) {
 
         // Check the length of the binary literal.
         int length = (int)(compiler->current_char - compiler->token_start);
-        if (length > STR_BIN_BUFF_SIZE - 2) { // -2: '-\0' 0b is in both side.
+        if (length > STR_BIN_BUFF_SIZE - 2) {  // -2: '-\0' 0b is in both side.
           lexError(compiler, "Binary literal is too long.");
           break;
         }
@@ -608,7 +609,7 @@ static void eatNumber(Compiler* compiler) {
     value = VAR_NUM((double)bin);
 
   } else if (c == '0' && peekChar(compiler) == 'x') {
-    eatChar(compiler); // Consume '0x'
+    eatChar(compiler);  // Consume '0x'
 
     uint64_t hex = 0;
     c = peekChar(compiler);
@@ -626,15 +627,15 @@ static void eatNumber(Compiler* compiler) {
 
         // Check the length of the binary literal.
         int length = (int)(compiler->current_char - compiler->token_start);
-        if (length > STR_HEX_BUFF_SIZE - 2) { // -2: '-\0' 0x is in both side.
+        if (length > STR_HEX_BUFF_SIZE - 2) {  // -2: '-\0' 0x is in both side.
           lexError(compiler, "Hex literal is too long.");
           break;
         }
 
         // "Append" the next digit at the end.
         uint8_t append_val = ('0' <= c && c <= '9')
-          ? (uint8_t)(c - '0')
-          : (uint8_t)((c - 'a') + 10);
+                                 ? (uint8_t)(c - '0')
+                                 : (uint8_t)((c - 'a') + 10);
         hex = (hex << 4) | append_val;
 
       } while (true);
@@ -642,7 +643,7 @@ static void eatNumber(Compiler* compiler) {
       value = VAR_NUM((double)hex);
     }
 
-  } else { // Regular number literal.
+  } else {  // Regular number literal.
     while (utilIsDigit(peekChar(compiler))) {
       eatChar(compiler);
     }
@@ -656,7 +657,6 @@ static void eatNumber(Compiler* compiler) {
 
     // Parse if in scientific notation format (MeN == M * 10 ** N).
     if (matchChar(compiler, 'e') || matchChar(compiler, 'E')) {
-
       if (peekChar(compiler) == '+' || peekChar(compiler) == '-') {
         eatChar(compiler);
       }
@@ -664,7 +664,7 @@ static void eatNumber(Compiler* compiler) {
       if (!utilIsDigit(peekChar(compiler))) {
         lexError(compiler, "Invalid number literal.");
 
-      } else { // Eat the exponent.
+      } else {  // Eat the exponent.
         while (utilIsDigit(peekChar(compiler))) eatChar(compiler);
       }
     }
@@ -705,7 +705,7 @@ static bool matchChar(Compiler* compiler, char c) {
 // If the current char is [c] eat the char and add token two otherwise eat
 // append token one.
 static void setNextTwoCharToken(Compiler* compiler, char c, TokenType one,
-  TokenType two) {
+                                TokenType two) {
   if (matchChar(compiler, c)) {
     setNextToken(compiler, two);
   } else {
@@ -740,21 +740,43 @@ static void lexToken(Compiler* compiler) {
     char c = eatChar(compiler);
 
     switch (c) {
-      case ',': setNextToken(compiler, TK_COMMA); return;
-      case ':': setNextToken(compiler, TK_COLLON); return;
-      case ';': setNextToken(compiler, TK_SEMICOLLON); return;
-      case '#': skipLineComment(compiler); break;
-      case '(': setNextToken(compiler, TK_LPARAN); return;
-      case ')': setNextToken(compiler, TK_RPARAN); return;
-      case '[': setNextToken(compiler, TK_LBRACKET); return;
-      case ']': setNextToken(compiler, TK_RBRACKET); return;
-      case '{': setNextToken(compiler, TK_LBRACE); return;
-      case '}': setNextToken(compiler, TK_RBRACE); return;
+      case ',':
+        setNextToken(compiler, TK_COMMA);
+        return;
+      case ':':
+        setNextToken(compiler, TK_COLLON);
+        return;
+      case ';':
+        setNextToken(compiler, TK_SEMICOLLON);
+        return;
+      case '#':
+        skipLineComment(compiler);
+        break;
+      case '(':
+        setNextToken(compiler, TK_LPARAN);
+        return;
+      case ')':
+        setNextToken(compiler, TK_RPARAN);
+        return;
+      case '[':
+        setNextToken(compiler, TK_LBRACKET);
+        return;
+      case ']':
+        setNextToken(compiler, TK_RBRACKET);
+        return;
+      case '{':
+        setNextToken(compiler, TK_LBRACE);
+        return;
+      case '}':
+        setNextToken(compiler, TK_RBRACE);
+        return;
       case '%':
         setNextTwoCharToken(compiler, '=', TK_PERCENT, TK_MODEQ);
         return;
 
-      case '~': setNextToken(compiler, TK_TILD); return;
+      case '~':
+        setNextToken(compiler, TK_TILD);
+        return;
 
       case '&':
         setNextTwoCharToken(compiler, '=', TK_AMP, TK_ANDEQ);
@@ -768,7 +790,9 @@ static void lexToken(Compiler* compiler) {
         setNextTwoCharToken(compiler, '=', TK_CARET, TK_XOREQ);
         return;
 
-      case '\n': setNextToken(compiler, TK_LINE); return;
+      case '\n':
+        setNextToken(compiler, TK_LINE);
+        return;
 
       case ' ':
       case '\t':
@@ -783,12 +807,12 @@ static void lexToken(Compiler* compiler) {
 
       case '.':
         if (matchChar(compiler, '.')) {
-          setNextToken(compiler, TK_DOTDOT); // '..'
+          setNextToken(compiler, TK_DOTDOT);  // '..'
         } else if (utilIsDigit(peekChar(compiler))) {
-          eatChar(compiler);   // Consume the decimal point.
-          eatNumber(compiler); // Consume the rest of the number
+          eatChar(compiler);    // Consume the decimal point.
+          eatNumber(compiler);  // Consume the rest of the number
         } else {
-          setNextToken(compiler, TK_DOT);    // '.'
+          setNextToken(compiler, TK_DOT);  // '.'
         }
         return;
 
@@ -832,9 +856,9 @@ static void lexToken(Compiler* compiler) {
         if (matchChar(compiler, '=')) {
           setNextToken(compiler, TK_MINUSEQ);  // '-='
         } else if (matchChar(compiler, '>')) {
-          setNextToken(compiler, TK_ARROW);    // '->'
+          setNextToken(compiler, TK_ARROW);  // '->'
         } else {
-          setNextToken(compiler, TK_MINUS);    // '-'
+          setNextToken(compiler, TK_MINUS);  // '-'
         }
         return;
 
@@ -846,12 +870,15 @@ static void lexToken(Compiler* compiler) {
         setNextTwoCharToken(compiler, '=', TK_FSLASH, TK_DIVEQ);
         return;
 
-      case '"': eatString(compiler, false); return;
+      case '"':
+        eatString(compiler, false);
+        return;
 
-      case '\'': eatString(compiler, true); return;
+      case '\'':
+        eatString(compiler, true);
+        return;
 
       default: {
-
         if (utilIsDigit(c)) {
           eatNumber(compiler);
 
@@ -880,9 +907,7 @@ static void lexToken(Compiler* compiler) {
 /*****************************************************************************/
 
 // Returns current token type without lexing a new token.
-static TokenType peek(Compiler* self) {
-  return self->current.type;
-}
+static TokenType peek(Compiler* self) { return self->current.type; }
 
 // Consume the current token if it's expected and lex for the next token
 // and return true otherwise return false.
@@ -895,7 +920,6 @@ static bool match(Compiler* self, TokenType expected) {
 // Consume the the current token and if it's not [expected] emits error log
 // and continue parsing for more error logs.
 static void consume(Compiler* self, TokenType expected, const char* err_msg) {
-
   lexToken(self);
   if (self->previous.type != expected) {
     parseError(self, "%s", err_msg);
@@ -910,19 +934,17 @@ static void consume(Compiler* self, TokenType expected, const char* err_msg) {
 
 // Match one or more lines and return true if there any.
 static bool matchLine(Compiler* compiler) {
-
   bool consumed = false;
 
   if (peek(compiler) == TK_LINE) {
-    while (peek(compiler) == TK_LINE)
-      lexToken(compiler);
+    while (peek(compiler) == TK_LINE) lexToken(compiler);
     consumed = true;
   }
 
   // If we're running on REPL mode, at the EOF and compile time error occurred,
   // signal the host to get more lines and try re-compiling it.
   if (compiler->options && compiler->options->repl_mode &&
-    !compiler->has_errors) {
+      !compiler->has_errors) {
     if (peek(compiler) == TK_EOF) {
       compiler->need_more_lines = true;
     }
@@ -932,9 +954,7 @@ static bool matchLine(Compiler* compiler) {
 }
 
 // Will skip multiple new lines.
-static void skipNewLines(Compiler* compiler) {
-  matchLine(compiler);
-}
+static void skipNewLines(Compiler* compiler) { matchLine(compiler); }
 
 // Match semi collon, multiple new lines or peek 'end', 'else', 'elsif'
 // keywords.
@@ -943,8 +963,7 @@ static bool matchEndStatement(Compiler* compiler) {
     skipNewLines(compiler);
     return true;
   }
-  if (matchLine(compiler) || peek(compiler) == TK_EOF)
-    return true;
+  if (matchLine(compiler) || peek(compiler) == TK_EOF) return true;
 
   // In the below statement we don't require any new lines or semicolons.
   // 'if cond then stmnt1 elsif cond2 then stmnt2 else stmnt3 end'
@@ -968,34 +987,34 @@ static void consumeStartBlock(Compiler* compiler, TokenType delimiter) {
 
   // Match optional "do" or "then".
   if (delimiter == TK_DO || delimiter == TK_THEN) {
-    if (match(compiler, delimiter))
-      consumed = true;
+    if (match(compiler, delimiter)) consumed = true;
   }
 
-  if (matchLine(compiler))
-    consumed = true;
+  if (matchLine(compiler)) consumed = true;
 
   if (!consumed) {
     const char* msg;
-    if (delimiter == TK_DO) msg = "Expected enter block with newline or 'do'.";
-    else msg = "Expected enter block with newline or 'then'.";
+    if (delimiter == TK_DO)
+      msg = "Expected enter block with newline or 'do'.";
+    else
+      msg = "Expected enter block with newline or 'then'.";
     parseError(compiler, msg);
   }
 }
 
 // Returns a optional compound assignment.
 static bool matchAssignment(Compiler* compiler) {
-  if (match(compiler, TK_EQ))       return true;
-  if (match(compiler, TK_PLUSEQ))   return true;
-  if (match(compiler, TK_MINUSEQ))  return true;
-  if (match(compiler, TK_STAREQ))   return true;
-  if (match(compiler, TK_DIVEQ))    return true;
-  if (match(compiler, TK_MODEQ))    return true;
-  if (match(compiler, TK_ANDEQ))    return true;
-  if (match(compiler, TK_OREQ))     return true;
-  if (match(compiler, TK_XOREQ))    return true;
+  if (match(compiler, TK_EQ)) return true;
+  if (match(compiler, TK_PLUSEQ)) return true;
+  if (match(compiler, TK_MINUSEQ)) return true;
+  if (match(compiler, TK_STAREQ)) return true;
+  if (match(compiler, TK_DIVEQ)) return true;
+  if (match(compiler, TK_MODEQ)) return true;
+  if (match(compiler, TK_ANDEQ)) return true;
+  if (match(compiler, TK_OREQ)) return true;
+  if (match(compiler, TK_XOREQ)) return true;
   if (match(compiler, TK_SRIGHTEQ)) return true;
-  if (match(compiler, TK_SLEFTEQ))  return true;
+  if (match(compiler, TK_SLEFTEQ)) return true;
 
   return false;
 }
@@ -1011,12 +1030,11 @@ typedef enum {
   NAME_GLOBAL_VAR,
   NAME_FUNCTION,
   NAME_CLASS,
-  NAME_BUILTIN,    //< Native builtin function.
+  NAME_BUILTIN,  //< Native builtin function.
 } NameDefnType;
 
 // Identifier search result.
 typedef struct {
-
   NameDefnType type;
 
   // Index in the variable/function buffer/array.
@@ -1029,8 +1047,7 @@ typedef struct {
 
 // Will check if the name already defined.
 static NameSearchResult compilerSearchName(Compiler* compiler,
-  const char* name, uint32_t length) {
-
+                                           const char* name, uint32_t length) {
   NameSearchResult result;
   result.type = NAME_NOT_DEFINED;
 
@@ -1053,7 +1070,7 @@ static NameSearchResult compilerSearchName(Compiler* compiler,
     }
   }
 
-  int index; // For storing the search result below.
+  int index;  // For storing the search result below.
 
   // Search through globals.
   index = scriptGetGlobals(compiler->script, name, length);
@@ -1139,89 +1156,89 @@ static void exprSubscript(Compiler* compiler);
 // true, false, null, self.
 static void exprValue(Compiler* compiler);
 
-#define NO_RULE { NULL,          NULL,          PREC_NONE }
+#define NO_RULE \
+  { NULL, NULL, PREC_NONE }
 #define NO_INFIX PREC_NONE
 
-GrammarRule rules[] = {  // Prefix       Infix             Infix Precedence
-  /* TK_ERROR      */   NO_RULE,
-  /* TK_EOF        */   NO_RULE,
-  /* TK_LINE       */   NO_RULE,
-  /* TK_DOT        */ { NULL,          exprAttrib,       PREC_ATTRIB },
-  /* TK_DOTDOT     */ { NULL,          exprBinaryOp,     PREC_RANGE },
-  /* TK_COMMA      */   NO_RULE,
-  /* TK_COLLON     */   NO_RULE,
-  /* TK_SEMICOLLON */   NO_RULE,
-  /* TK_HASH       */   NO_RULE,
-  /* TK_LPARAN     */ { exprGrouping,  exprCall,         PREC_CALL },
-  /* TK_RPARAN     */   NO_RULE,
-  /* TK_LBRACKET   */ { exprList,      exprSubscript,    PREC_SUBSCRIPT },
-  /* TK_RBRACKET   */   NO_RULE,
-  /* TK_LBRACE     */ { exprMap,       NULL,             NO_INFIX },
-  /* TK_RBRACE     */   NO_RULE,
-  /* TK_PERCENT    */ { NULL,          exprBinaryOp,     PREC_FACTOR },
-  /* TK_TILD       */ { exprUnaryOp,   NULL,             NO_INFIX },
-  /* TK_AMP        */ { NULL,          exprBinaryOp,     PREC_BITWISE_AND },
-  /* TK_PIPE       */ { NULL,          exprBinaryOp,     PREC_BITWISE_OR },
-  /* TK_CARET      */ { NULL,          exprBinaryOp,     PREC_BITWISE_XOR },
-  /* TK_ARROW      */ { NULL,          exprChainCall,    PREC_CHAIN_CALL },
-  /* TK_PLUS       */ { NULL,          exprBinaryOp,     PREC_TERM },
-  /* TK_MINUS      */ { exprUnaryOp,   exprBinaryOp,     PREC_TERM },
-  /* TK_STAR       */ { NULL,          exprBinaryOp,     PREC_FACTOR },
-  /* TK_FSLASH     */ { NULL,          exprBinaryOp,     PREC_FACTOR },
-  /* TK_BSLASH     */   NO_RULE,
-  /* TK_EQ         */   NO_RULE,
-  /* TK_GT         */ { NULL,          exprBinaryOp,     PREC_COMPARISION },
-  /* TK_LT         */ { NULL,          exprBinaryOp,     PREC_COMPARISION },
-  /* TK_EQEQ       */ { NULL,          exprBinaryOp,     PREC_EQUALITY },
-  /* TK_NOTEQ      */ { NULL,          exprBinaryOp,     PREC_EQUALITY },
-  /* TK_GTEQ       */ { NULL,          exprBinaryOp,     PREC_COMPARISION },
-  /* TK_LTEQ       */ { NULL,          exprBinaryOp,     PREC_COMPARISION },
-  /* TK_PLUSEQ     */   NO_RULE,
-  /* TK_MINUSEQ    */   NO_RULE,
-  /* TK_STAREQ     */   NO_RULE,
-  /* TK_DIVEQ      */   NO_RULE,
-  /* TK_MODEQ      */   NO_RULE,
-  /* TK_ANDEQ      */   NO_RULE,
-  /* TK_OREQ       */   NO_RULE,
-  /* TK_XOREQ      */   NO_RULE,
-  /* TK_SRIGHT     */ { NULL,          exprBinaryOp,     PREC_BITWISE_SHIFT },
-  /* TK_SLEFT      */ { NULL,          exprBinaryOp,     PREC_BITWISE_SHIFT },
-  /* TK_SRIGHTEQ   */   NO_RULE,
-  /* TK_SLEFTEQ    */   NO_RULE,
-  /* TK_MODULE     */   NO_RULE,
-  /* TK_CLASS      */   NO_RULE,
-  /* TK_FROM       */   NO_RULE,
-  /* TK_IMPORT     */   NO_RULE,
-  /* TK_AS         */   NO_RULE,
-  /* TK_DEF        */   NO_RULE,
-  /* TK_EXTERN     */   NO_RULE,
-  /* TK_FUNC       */ { exprFunc,      NULL,             NO_INFIX },
-  /* TK_END        */   NO_RULE,
-  /* TK_NULL       */ { exprValue,     NULL,             NO_INFIX },
-  /* TK_IN         */ { NULL,          exprBinaryOp,     PREC_TEST },
-  /* TK_AND        */ { NULL,          exprAnd,          PREC_LOGICAL_AND },
-  /* TK_OR         */ { NULL,          exprOr,           PREC_LOGICAL_OR },
-  /* TK_NOT        */ { exprUnaryOp,   NULL,             PREC_UNARY },
-  /* TK_TRUE       */ { exprValue,     NULL,             NO_INFIX },
-  /* TK_FALSE      */ { exprValue,     NULL,             NO_INFIX },
-  /* TK_DO         */   NO_RULE,
-  /* TK_THEN       */   NO_RULE,
-  /* TK_WHILE      */   NO_RULE,
-  /* TK_FOR        */   NO_RULE,
-  /* TK_IF         */   NO_RULE,
-  /* TK_ELSIF      */   NO_RULE,
-  /* TK_ELSE       */   NO_RULE,
-  /* TK_BREAK      */   NO_RULE,
-  /* TK_CONTINUE   */   NO_RULE,
-  /* TK_RETURN     */   NO_RULE,
-  /* TK_NAME       */ { exprName,      NULL,             NO_INFIX },
-  /* TK_NUMBER     */ { exprLiteral,   NULL,             NO_INFIX },
-  /* TK_STRING     */ { exprLiteral,   NULL,             NO_INFIX },
+GrammarRule rules[] = {
+    // Prefix       Infix             Infix Precedence
+    /* TK_ERROR      */ NO_RULE,
+    /* TK_EOF        */ NO_RULE,
+    /* TK_LINE       */ NO_RULE,
+    /* TK_DOT        */ {NULL, exprAttrib, PREC_ATTRIB},
+    /* TK_DOTDOT     */ {NULL, exprBinaryOp, PREC_RANGE},
+    /* TK_COMMA      */ NO_RULE,
+    /* TK_COLLON     */ NO_RULE,
+    /* TK_SEMICOLLON */ NO_RULE,
+    /* TK_HASH       */ NO_RULE,
+    /* TK_LPARAN     */ {exprGrouping, exprCall, PREC_CALL},
+    /* TK_RPARAN     */ NO_RULE,
+    /* TK_LBRACKET   */ {exprList, exprSubscript, PREC_SUBSCRIPT},
+    /* TK_RBRACKET   */ NO_RULE,
+    /* TK_LBRACE     */ {exprMap, NULL, NO_INFIX},
+    /* TK_RBRACE     */ NO_RULE,
+    /* TK_PERCENT    */ {NULL, exprBinaryOp, PREC_FACTOR},
+    /* TK_TILD       */ {exprUnaryOp, NULL, NO_INFIX},
+    /* TK_AMP        */ {NULL, exprBinaryOp, PREC_BITWISE_AND},
+    /* TK_PIPE       */ {NULL, exprBinaryOp, PREC_BITWISE_OR},
+    /* TK_CARET      */ {NULL, exprBinaryOp, PREC_BITWISE_XOR},
+    /* TK_ARROW      */ {NULL, exprChainCall, PREC_CHAIN_CALL},
+    /* TK_PLUS       */ {NULL, exprBinaryOp, PREC_TERM},
+    /* TK_MINUS      */ {exprUnaryOp, exprBinaryOp, PREC_TERM},
+    /* TK_STAR       */ {NULL, exprBinaryOp, PREC_FACTOR},
+    /* TK_FSLASH     */ {NULL, exprBinaryOp, PREC_FACTOR},
+    /* TK_BSLASH     */ NO_RULE,
+    /* TK_EQ         */ NO_RULE,
+    /* TK_GT         */ {NULL, exprBinaryOp, PREC_COMPARISION},
+    /* TK_LT         */ {NULL, exprBinaryOp, PREC_COMPARISION},
+    /* TK_EQEQ       */ {NULL, exprBinaryOp, PREC_EQUALITY},
+    /* TK_NOTEQ      */ {NULL, exprBinaryOp, PREC_EQUALITY},
+    /* TK_GTEQ       */ {NULL, exprBinaryOp, PREC_COMPARISION},
+    /* TK_LTEQ       */ {NULL, exprBinaryOp, PREC_COMPARISION},
+    /* TK_PLUSEQ     */ NO_RULE,
+    /* TK_MINUSEQ    */ NO_RULE,
+    /* TK_STAREQ     */ NO_RULE,
+    /* TK_DIVEQ      */ NO_RULE,
+    /* TK_MODEQ      */ NO_RULE,
+    /* TK_ANDEQ      */ NO_RULE,
+    /* TK_OREQ       */ NO_RULE,
+    /* TK_XOREQ      */ NO_RULE,
+    /* TK_SRIGHT     */ {NULL, exprBinaryOp, PREC_BITWISE_SHIFT},
+    /* TK_SLEFT      */ {NULL, exprBinaryOp, PREC_BITWISE_SHIFT},
+    /* TK_SRIGHTEQ   */ NO_RULE,
+    /* TK_SLEFTEQ    */ NO_RULE,
+    /* TK_MODULE     */ NO_RULE,
+    /* TK_CLASS      */ NO_RULE,
+    /* TK_FROM       */ NO_RULE,
+    /* TK_IMPORT     */ NO_RULE,
+    /* TK_AS         */ NO_RULE,
+    /* TK_DEF        */ NO_RULE,
+    /* TK_EXTERN     */ NO_RULE,
+    /* TK_FUNC       */ {exprFunc, NULL, NO_INFIX},
+    /* TK_END        */ NO_RULE,
+    /* TK_NULL       */ {exprValue, NULL, NO_INFIX},
+    /* TK_IN         */ {NULL, exprBinaryOp, PREC_TEST},
+    /* TK_AND        */ {NULL, exprAnd, PREC_LOGICAL_AND},
+    /* TK_OR         */ {NULL, exprOr, PREC_LOGICAL_OR},
+    /* TK_NOT        */ {exprUnaryOp, NULL, PREC_UNARY},
+    /* TK_TRUE       */ {exprValue, NULL, NO_INFIX},
+    /* TK_FALSE      */ {exprValue, NULL, NO_INFIX},
+    /* TK_DO         */ NO_RULE,
+    /* TK_THEN       */ NO_RULE,
+    /* TK_WHILE      */ NO_RULE,
+    /* TK_FOR        */ NO_RULE,
+    /* TK_IF         */ NO_RULE,
+    /* TK_ELSIF      */ NO_RULE,
+    /* TK_ELSE       */ NO_RULE,
+    /* TK_BREAK      */ NO_RULE,
+    /* TK_CONTINUE   */ NO_RULE,
+    /* TK_RETURN     */ NO_RULE,
+    /* TK_NAME       */ {exprName, NULL, NO_INFIX},
+    /* TK_NUMBER     */ {exprLiteral, NULL, NO_INFIX},
+    /* TK_STRING     */ {exprLiteral, NULL, NO_INFIX},
 };
 
-static GrammarRule* getRule(TokenType type) {
-  return &(rules[(int)type]);
-}
+static GrammarRule* getRule(TokenType type) { return &(rules[(int)type]); }
 
 // Emit variable store.
 static void emitStoreVariable(Compiler* compiler, int index, bool global) {
@@ -1230,7 +1247,7 @@ static void emitStoreVariable(Compiler* compiler, int index, bool global) {
     emitByte(compiler, index);
 
   } else {
-    if (index < 9) { //< 0..8 locals have single opcode.
+    if (index < 9) {  //< 0..8 locals have single opcode.
       emitOpcode(compiler, (Opcode)(OP_STORE_LOCAL_0 + index));
     } else {
       emitOpcode(compiler, OP_STORE_LOCAL_N);
@@ -1245,7 +1262,7 @@ static void emitPushVariable(Compiler* compiler, int index, bool global) {
     emitByte(compiler, index);
 
   } else {
-    if (index < 9) { //< 0..8 locals have single opcode.
+    if (index < 9) {  //< 0..8 locals have single opcode.
       emitOpcode(compiler, (Opcode)(OP_PUSH_LOCAL_0 + index));
     } else {
       emitOpcode(compiler, OP_PUSH_LOCAL_N);
@@ -1273,7 +1290,6 @@ static void exprFunc(Compiler* compiler) {
 
 // Local/global variables, script/native/builtin functions name.
 static void exprName(Compiler* compiler) {
-
   const char* start = compiler->previous.start;
   int length = compiler->previous.length;
   int line = compiler->previous.line;
@@ -1299,7 +1315,6 @@ static void exprName(Compiler* compiler) {
         emitStoreVariable(compiler, index, false);
       }
     } else {
-
       // The name could be a function which hasn't been defined at this point.
       if (peek(compiler) == TK_LPARAN) {
         emitOpcode(compiler, OP_PUSH_FN);
@@ -1311,7 +1326,6 @@ static void exprName(Compiler* compiler) {
     }
 
   } else {
-
     switch (result.type) {
       case NAME_LOCAL_VAR:
       case NAME_GLOBAL_VAR: {
@@ -1354,7 +1368,7 @@ static void exprName(Compiler* compiler) {
         break;
 
       case NAME_NOT_DEFINED:
-        UNREACHABLE(); // Case already handled.
+        UNREACHABLE();  // Case already handled.
     }
   }
 
@@ -1375,15 +1389,15 @@ static void exprName(Compiler* compiler) {
 
 void exprOr(Compiler* compiler) {
   emitOpcode(compiler, OP_JUMP_IF);
-  int true_offset_a = emitShort(compiler, 0xffff); //< Will be patched.
+  int true_offset_a = emitShort(compiler, 0xffff);  //< Will be patched.
 
   parsePrecedence(compiler, PREC_LOGICAL_OR);
   emitOpcode(compiler, OP_JUMP_IF);
-  int true_offset_b = emitShort(compiler, 0xffff); //< Will be patched.
+  int true_offset_b = emitShort(compiler, 0xffff);  //< Will be patched.
 
   emitOpcode(compiler, OP_PUSH_FALSE);
   emitOpcode(compiler, OP_JUMP);
-  int end_offset = emitShort(compiler, 0xffff); //< Will be patched.
+  int end_offset = emitShort(compiler, 0xffff);  //< Will be patched.
 
   patchJump(compiler, true_offset_a);
   patchJump(compiler, true_offset_b);
@@ -1396,15 +1410,15 @@ void exprOr(Compiler* compiler) {
 
 void exprAnd(Compiler* compiler) {
   emitOpcode(compiler, OP_JUMP_IF_NOT);
-  int false_offset_a = emitShort(compiler, 0xffff); //< Will be patched.
+  int false_offset_a = emitShort(compiler, 0xffff);  //< Will be patched.
 
   parsePrecedence(compiler, PREC_LOGICAL_AND);
   emitOpcode(compiler, OP_JUMP_IF_NOT);
-  int false_offset_b = emitShort(compiler, 0xffff); //< Will be patched.
+  int false_offset_b = emitShort(compiler, 0xffff);  //< Will be patched.
 
   emitOpcode(compiler, OP_PUSH_TRUE);
   emitOpcode(compiler, OP_JUMP);
-  int end_offset = emitShort(compiler, 0xffff); //< Will be patched.
+  int end_offset = emitShort(compiler, 0xffff);  //< Will be patched.
 
   patchJump(compiler, false_offset_a);
   patchJump(compiler, false_offset_b);
@@ -1418,9 +1432,9 @@ void exprAnd(Compiler* compiler) {
 static void exprChainCall(Compiler* compiler) {
   skipNewLines(compiler);
   parsePrecedence(compiler, (Precedence)(PREC_CHAIN_CALL + 1));
-  emitOpcode(compiler, OP_SWAP); // Swap the data with the function.
+  emitOpcode(compiler, OP_SWAP);  // Swap the data with the function.
 
-  int argc = 1; // The initial data.
+  int argc = 1;  // The initial data.
 
   if (match(compiler, TK_LBRACE)) {
     if (!match(compiler, TK_RBRACE)) {
@@ -1430,8 +1444,9 @@ static void exprChainCall(Compiler* compiler) {
         skipNewLines(compiler);
         argc++;
       } while (match(compiler, TK_COMMA));
-      consume(compiler, TK_RBRACE, "Expected '}' after chain call "
-                                   "parameter list.");
+      consume(compiler, TK_RBRACE,
+              "Expected '}' after chain call "
+              "parameter list.");
     }
   }
 
@@ -1449,24 +1464,60 @@ static void exprBinaryOp(Compiler* compiler) {
   parsePrecedence(compiler, (Precedence)(getRule(op)->precedence + 1));
 
   switch (op) {
-    case TK_DOTDOT:  emitOpcode(compiler, OP_RANGE);      break;
-    case TK_PERCENT: emitOpcode(compiler, OP_MOD);        break;
-    case TK_AMP:     emitOpcode(compiler, OP_BIT_AND);    break;
-    case TK_PIPE:    emitOpcode(compiler, OP_BIT_OR);     break;
-    case TK_CARET:   emitOpcode(compiler, OP_BIT_XOR);    break;
-    case TK_PLUS:    emitOpcode(compiler, OP_ADD);        break;
-    case TK_MINUS:   emitOpcode(compiler, OP_SUBTRACT);   break;
-    case TK_STAR:    emitOpcode(compiler, OP_MULTIPLY);   break;
-    case TK_FSLASH:  emitOpcode(compiler, OP_DIVIDE);     break;
-    case TK_GT:      emitOpcode(compiler, OP_GT);         break;
-    case TK_LT:      emitOpcode(compiler, OP_LT);         break;
-    case TK_EQEQ:    emitOpcode(compiler, OP_EQEQ);       break;
-    case TK_NOTEQ:   emitOpcode(compiler, OP_NOTEQ);      break;
-    case TK_GTEQ:    emitOpcode(compiler, OP_GTEQ);       break;
-    case TK_LTEQ:    emitOpcode(compiler, OP_LTEQ);       break;
-    case TK_SRIGHT:  emitOpcode(compiler, OP_BIT_RSHIFT); break;
-    case TK_SLEFT:   emitOpcode(compiler, OP_BIT_LSHIFT); break;
-    case TK_IN:      emitOpcode(compiler, OP_IN);         break;
+    case TK_DOTDOT:
+      emitOpcode(compiler, OP_RANGE);
+      break;
+    case TK_PERCENT:
+      emitOpcode(compiler, OP_MOD);
+      break;
+    case TK_AMP:
+      emitOpcode(compiler, OP_BIT_AND);
+      break;
+    case TK_PIPE:
+      emitOpcode(compiler, OP_BIT_OR);
+      break;
+    case TK_CARET:
+      emitOpcode(compiler, OP_BIT_XOR);
+      break;
+    case TK_PLUS:
+      emitOpcode(compiler, OP_ADD);
+      break;
+    case TK_MINUS:
+      emitOpcode(compiler, OP_SUBTRACT);
+      break;
+    case TK_STAR:
+      emitOpcode(compiler, OP_MULTIPLY);
+      break;
+    case TK_FSLASH:
+      emitOpcode(compiler, OP_DIVIDE);
+      break;
+    case TK_GT:
+      emitOpcode(compiler, OP_GT);
+      break;
+    case TK_LT:
+      emitOpcode(compiler, OP_LT);
+      break;
+    case TK_EQEQ:
+      emitOpcode(compiler, OP_EQEQ);
+      break;
+    case TK_NOTEQ:
+      emitOpcode(compiler, OP_NOTEQ);
+      break;
+    case TK_GTEQ:
+      emitOpcode(compiler, OP_GTEQ);
+      break;
+    case TK_LTEQ:
+      emitOpcode(compiler, OP_LTEQ);
+      break;
+    case TK_SRIGHT:
+      emitOpcode(compiler, OP_BIT_RSHIFT);
+      break;
+    case TK_SLEFT:
+      emitOpcode(compiler, OP_BIT_LSHIFT);
+      break;
+    case TK_IN:
+      emitOpcode(compiler, OP_IN);
+      break;
     default:
       UNREACHABLE();
   }
@@ -1480,9 +1531,15 @@ static void exprUnaryOp(Compiler* compiler) {
   parsePrecedence(compiler, (Precedence)(PREC_UNARY + 1));
 
   switch (op) {
-    case TK_TILD:  emitOpcode(compiler, OP_BIT_NOT); break;
-    case TK_MINUS: emitOpcode(compiler, OP_NEGATIVE); break;
-    case TK_NOT:   emitOpcode(compiler, OP_NOT); break;
+    case TK_TILD:
+      emitOpcode(compiler, OP_BIT_NOT);
+      break;
+    case TK_MINUS:
+      emitOpcode(compiler, OP_NEGATIVE);
+      break;
+    case TK_NOT:
+      emitOpcode(compiler, OP_NOT);
+      break;
     default:
       UNREACHABLE();
   }
@@ -1500,7 +1557,6 @@ static void exprGrouping(Compiler* compiler) {
 }
 
 static void exprList(Compiler* compiler) {
-
   emitOpcode(compiler, OP_PUSH_LIST);
   int size_index = emitShort(compiler, 0);
 
@@ -1548,7 +1604,6 @@ static void exprMap(Compiler* compiler) {
 }
 
 static void exprCall(Compiler* compiler) {
-
   // Compile parameters.
   int argc = 0;
   if (!match(compiler, TK_RPARAN)) {
@@ -1627,9 +1682,15 @@ static void exprSubscript(Compiler* compiler) {
 static void exprValue(Compiler* compiler) {
   TokenType op = compiler->previous.type;
   switch (op) {
-    case TK_NULL:  emitOpcode(compiler, OP_PUSH_NULL);  break;
-    case TK_TRUE:  emitOpcode(compiler, OP_PUSH_TRUE);  break;
-    case TK_FALSE: emitOpcode(compiler, OP_PUSH_FALSE); break;
+    case TK_NULL:
+      emitOpcode(compiler, OP_PUSH_NULL);
+      break;
+    case TK_TRUE:
+      emitOpcode(compiler, OP_PUSH_TRUE);
+      break;
+    case TK_FALSE:
+      emitOpcode(compiler, OP_PUSH_FALSE);
+      break;
     default:
       UNREACHABLE();
   }
@@ -1666,7 +1727,6 @@ static void parsePrecedence(Compiler* compiler, Precedence precedence) {
 
 static void compilerInit(Compiler* compiler, PKVM* vm, const char* source,
                          Script* script, const PkCompileOptions* options) {
-
   compiler->vm = vm;
   compiler->next_compiler = NULL;
 
@@ -1700,13 +1760,12 @@ static void compilerInit(Compiler* compiler, PKVM* vm, const char* source,
 // Add a variable and return it's index to the context. Assumes that the
 // variable name is unique and not defined before in the current scope.
 static int compilerAddVariable(Compiler* compiler, const char* name,
-                                uint32_t length, int line) {
-
+                               uint32_t length, int line) {
   // TODO: should I validate the name for pre-defined, etc?
 
   // Check if maximum variable count is reached.
   bool max_vars_reached = false;
-  const char* var_type = ""; // For max variables reached error message.
+  const char* var_type = "";  // For max variables reached error message.
   if (compiler->scope_depth == DEPTH_GLOBAL) {
     if (compiler->script->globals.count >= MAX_VARIABLES) {
       max_vars_reached = true;
@@ -1727,10 +1786,10 @@ static int compilerAddVariable(Compiler* compiler, const char* name,
   // Add the variable and return it's index.
 
   if (compiler->scope_depth == DEPTH_GLOBAL) {
-    return (int)scriptAddGlobal(compiler->vm, compiler->script,
-                                name, length, VAR_NULL);
+    return (int)scriptAddGlobal(compiler->vm, compiler->script, name, length,
+                                VAR_NULL);
   } else {
-    Local* local = &compiler->locals [compiler->local_count];
+    Local* local = &compiler->locals[compiler->local_count];
     local->name = name;
     local->length = length;
     local->depth = compiler->scope_depth;
@@ -1744,8 +1803,10 @@ static int compilerAddVariable(Compiler* compiler, const char* name,
 static void compilerAddForward(Compiler* compiler, int instruction, Fn* fn,
                                const char* name, int length, int line) {
   if (compiler->forwards_count == MAX_FORWARD_NAMES) {
-    parseError(compiler, "A script should contain at most %d implicit forward "
-               "function declarations.", MAX_FORWARD_NAMES);
+    parseError(compiler,
+               "A script should contain at most %d implicit forward "
+               "function declarations.",
+               MAX_FORWARD_NAMES);
     return;
   }
 
@@ -1771,16 +1832,16 @@ static int compilerAddConstant(Compiler* compiler, Var value) {
   if (literals->count < MAX_CONSTANTS) {
     pkVarBufferWrite(literals, compiler->vm, value);
   } else {
-    parseError(compiler, "A script should contain at most %d "
-               "unique constants.", MAX_CONSTANTS);
+    parseError(compiler,
+               "A script should contain at most %d "
+               "unique constants.",
+               MAX_CONSTANTS);
   }
   return (int)literals->count - 1;
 }
 
 // Enters inside a block.
-static void compilerEnterBlock(Compiler* compiler) {
-  compiler->scope_depth++;
-}
+static void compilerEnterBlock(Compiler* compiler) { compiler->scope_depth++; }
 
 // Change the stack size by the [num], if it's positive, the stack will
 // grow otherwise it'll shrink.
@@ -1807,7 +1868,6 @@ static int compilerPopLocals(Compiler* compiler, int depth) {
 
   int local = compiler->local_count - 1;
   while (local >= 0 && compiler->locals[local].depth >= depth) {
-
     // Note: Do not use emitOpcode(compiler, OP_POP);
     // Because this function is called at the middle of a scope (break,
     // continue). So we need the pop instruction here but we still need the
@@ -1831,8 +1891,8 @@ static void compilerExitBlock(Compiler* compiler) {
   compiler->scope_depth--;
 }
 
-static void compilerPushFunc(Compiler* compiler, Func* fn,
-                             Function* func, int index) {
+static void compilerPushFunc(Compiler* compiler, Func* fn, Function* func,
+                             int index) {
   fn->outer_func = compiler->func;
   fn->ptr = func;
   fn->depth = compiler->scope_depth;
@@ -1850,11 +1910,8 @@ static void compilerPopFunc(Compiler* compiler) {
 
 // Emit a single byte and return it's index.
 static int emitByte(Compiler* compiler, int byte) {
-
-  pkByteBufferWrite(&_FN->opcodes, compiler->vm,
-                    (uint8_t)byte);
-  pkUintBufferWrite(&_FN->oplines, compiler->vm,
-                   compiler->previous.line);
+  pkByteBufferWrite(&_FN->opcodes, compiler->vm, (uint8_t)byte);
+  pkUintBufferWrite(&_FN->oplines, compiler->vm, compiler->previous.line);
   return (int)_FN->opcodes.count - 1;
 }
 
@@ -1880,16 +1937,36 @@ static void emitLoopJump(Compiler* compiler) {
 
 static void emitAssignment(Compiler* compiler, TokenType assignment) {
   switch (assignment) {
-    case TK_PLUSEQ:   emitOpcode(compiler, OP_ADD);        break;
-    case TK_MINUSEQ:  emitOpcode(compiler, OP_SUBTRACT);   break;
-    case TK_STAREQ:   emitOpcode(compiler, OP_MULTIPLY);   break;
-    case TK_DIVEQ:    emitOpcode(compiler, OP_DIVIDE);     break;
-    case TK_MODEQ:    emitOpcode(compiler, OP_MOD);        break;
-    case TK_ANDEQ:    emitOpcode(compiler, OP_BIT_AND);    break;
-    case TK_OREQ:     emitOpcode(compiler, OP_BIT_OR);     break;
-    case TK_XOREQ:    emitOpcode(compiler, OP_BIT_XOR);    break;
-    case TK_SRIGHTEQ: emitOpcode(compiler, OP_BIT_RSHIFT); break;
-    case TK_SLEFTEQ:  emitOpcode(compiler, OP_BIT_LSHIFT); break;
+    case TK_PLUSEQ:
+      emitOpcode(compiler, OP_ADD);
+      break;
+    case TK_MINUSEQ:
+      emitOpcode(compiler, OP_SUBTRACT);
+      break;
+    case TK_STAREQ:
+      emitOpcode(compiler, OP_MULTIPLY);
+      break;
+    case TK_DIVEQ:
+      emitOpcode(compiler, OP_DIVIDE);
+      break;
+    case TK_MODEQ:
+      emitOpcode(compiler, OP_MOD);
+      break;
+    case TK_ANDEQ:
+      emitOpcode(compiler, OP_BIT_AND);
+      break;
+    case TK_OREQ:
+      emitOpcode(compiler, OP_BIT_OR);
+      break;
+    case TK_XOREQ:
+      emitOpcode(compiler, OP_BIT_XOR);
+      break;
+    case TK_SRIGHTEQ:
+      emitOpcode(compiler, OP_BIT_RSHIFT);
+      break;
+    case TK_SLEFTEQ:
+      emitOpcode(compiler, OP_BIT_LSHIFT);
+      break;
     default:
       UNREACHABLE();
       break;
@@ -1897,7 +1974,6 @@ static void emitAssignment(Compiler* compiler, TokenType assignment) {
 }
 
 static void emitFunctionEnd(Compiler* compiler) {
-
   // Don't use emitOpcode(compiler, OP_RETURN); Because it'll recude the stack
   // size by -1, (return value will be popped). We really don't have to pop the
   // return value of the function, when returning from the end of the function,
@@ -1937,7 +2013,6 @@ static void compileBlockBody(Compiler* compiler, BlockType type);
 
 // Compile a type and return it's index in the script's types buffer.
 static int compileType(Compiler* compiler) {
-
   // Consume the name of the type.
   consume(compiler, TK_NAME, "Expected a type name.");
   const char* name = compiler->previous.start;
@@ -1948,8 +2023,8 @@ static int compileType(Compiler* compiler) {
   }
 
   // Create a new type.
-  Class* type = newClass(compiler->vm, compiler->script,
-                         name, (uint32_t)name_len);
+  Class* type =
+      newClass(compiler->vm, compiler->script, name, (uint32_t)name_len);
   type->ctor->arity = 0;
 
   // Check count exceeded.
@@ -1978,14 +2053,13 @@ static int compileType(Compiler* compiler) {
   skipNewLines(compiler);
   TokenType next = peek(compiler);
   while (next != TK_END && next != TK_EOF) {
-
     // Compile field name.
     consume(compiler, TK_NAME, "Expected a type name.");
     const char* f_name = compiler->previous.start;
     int f_len = compiler->previous.length;
 
-    uint32_t f_index = scriptAddName(compiler->script, compiler->vm,
-                                     f_name, f_len);
+    uint32_t f_index =
+        scriptAddName(compiler->script, compiler->vm, f_name, f_len);
 
     // TODO: Add a string compare macro.
     String* new_name = compiler->script->names.data[f_index];
@@ -2002,7 +2076,7 @@ static int compileType(Compiler* compiler) {
 
     // Consume the assignment expression.
     consume(compiler, TK_EQ, "Expected an assignment after field name.");
-    compileExpression(compiler); // Assigned value.
+    compileExpression(compiler);  // Assigned value.
     consumeEndStatement(compiler);
 
     // At this point the stack top would be the expression.
@@ -2020,12 +2094,11 @@ static int compileType(Compiler* compiler) {
 
   compilerPopFunc(compiler);
 
-  return -1; // TODO;
+  return -1;  // TODO;
 }
 
 // Compile a function and return it's index in the script's function buffer.
 static int compileFunction(Compiler* compiler, FuncType fn_type) {
-
   const char* name;
   int name_length;
 
@@ -2055,7 +2128,7 @@ static int compileFunction(Compiler* compiler, FuncType fn_type) {
   compilerPushFunc(compiler, &curr_fn, func, fn_index);
 
   int argc = 0;
-  compilerEnterBlock(compiler); // Parameter depth.
+  compilerEnterBlock(compiler);  // Parameter depth.
 
   // Parameter list is optional.
   if (match(compiler, TK_LPARAN) && !match(compiler, TK_RPARAN)) {
@@ -2100,7 +2173,7 @@ static int compileFunction(Compiler* compiler, FuncType fn_type) {
     // Tail call optimization disabled at debug mode.
     if (compiler->options && !compiler->options->debug) {
       if (compiler->is_last_call) {
-        ASSERT(_FN->opcodes.count >= 3, OOPS); // OP_CALL, argc, OP_POP
+        ASSERT(_FN->opcodes.count >= 3, OOPS);  // OP_CALL, argc, OP_POP
         ASSERT(_FN->opcodes.data[_FN->opcodes.count - 1] == OP_POP, OOPS);
         ASSERT(_FN->opcodes.data[_FN->opcodes.count - 3] == OP_CALL, OOPS);
         _FN->opcodes.data[_FN->opcodes.count - 3] = OP_TAIL_CALL;
@@ -2108,11 +2181,11 @@ static int compileFunction(Compiler* compiler, FuncType fn_type) {
     }
 
     consume(compiler, TK_END, "Expected 'end' after function definition end.");
-    compilerExitBlock(compiler); // Parameter depth.
+    compilerExitBlock(compiler);  // Parameter depth.
     emitFunctionEnd(compiler);
 
   } else {
-    compilerExitBlock(compiler); // Parameter depth.
+    compilerExitBlock(compiler);  // Parameter depth.
   }
 
 #if DEBUG_DUMP_COMPILED_CODE
@@ -2130,7 +2203,6 @@ static int compileFunction(Compiler* compiler, FuncType fn_type) {
 
 // Finish a block body.
 static void compileBlockBody(Compiler* compiler, BlockType type) {
-
   compilerEnterBlock(compiler);
 
   if (type == BLOCK_IF) {
@@ -2151,9 +2223,8 @@ static void compileBlockBody(Compiler* compiler, BlockType type) {
   }
 
   TokenType next = peek(compiler);
-  while (!(next == TK_END || next == TK_EOF || (
-    (type == BLOCK_IF) && (next == TK_ELSE || next == TK_ELSIF)))) {
-
+  while (!(next == TK_END || next == TK_EOF ||
+           ((type == BLOCK_IF) && (next == TK_ELSE || next == TK_ELSIF)))) {
     compileStatement(compiler);
     skipNewLines(compiler);
 
@@ -2172,10 +2243,10 @@ static Script* importFile(Compiler* compiler, const char* path) {
   PKVM* vm = compiler->vm;
 
   // Resolve the path.
-  PkStringPtr resolved = { path, NULL, NULL };
+  PkStringPtr resolved = {path, NULL, NULL};
   if (vm->config.resolve_path_fn != NULL) {
-    resolved = vm->config.resolve_path_fn(vm, compiler->script->path->data,
-                                          path);
+    resolved =
+        vm->config.resolve_path_fn(vm, compiler->script->path->data, path);
   }
 
   if (resolved.string == NULL) {
@@ -2184,8 +2255,9 @@ static Script* importFile(Compiler* compiler, const char* path) {
   }
 
   // Create new string for the resolved path. And free the resolved path.
-  int index = (int)scriptAddName(compiler->script, compiler->vm,
-                           resolved.string, (uint32_t)strlen(resolved.string));
+  int index =
+      (int)scriptAddName(compiler->script, compiler->vm, resolved.string,
+                         (uint32_t)strlen(resolved.string));
   String* path_name = compiler->script->names.data[index];
   if (resolved.on_done != NULL) resolved.on_done(vm, resolved);
 
@@ -2202,7 +2274,8 @@ static Script* importFile(Compiler* compiler, const char* path) {
 
   // The script not exists, make sure we have the script loading api function.
   if (vm->config.load_script_fn == NULL) {
-    parseError(compiler, "Cannot import. The hosting application haven't "
+    parseError(compiler,
+               "Cannot import. The hosting application haven't "
                "registered the script loading API");
     return NULL;
   }
@@ -2216,9 +2289,9 @@ static Script* importFile(Compiler* compiler, const char* path) {
 
   // Make a new script and to compile it.
   Script* scr = newScript(vm, path_name, false);
-  vmPushTempRef(vm, &scr->_super); // scr.
+  vmPushTempRef(vm, &scr->_super);  // scr.
   mapSet(vm, vm->scripts, VAR_OBJ(path_name), VAR_OBJ(scr));
-  vmPopTempRef(vm); // scr.
+  vmPopTempRef(vm);  // scr.
 
   // Push the script on the stack.
   emitOpcode(compiler, OP_IMPORT);
@@ -2250,8 +2323,8 @@ static Script* importCoreLib(Compiler* compiler, const char* name_start,
 
   // Add the name to the script's name buffer, we need it as a key to the
   // vm's script cache.
-  int index = (int)scriptAddName(compiler->script, compiler->vm,
-                                 name_start, name_length);
+  int index = (int)scriptAddName(compiler->script, compiler->vm, name_start,
+                                 name_length);
   String* module = compiler->script->names.data[index];
 
   Var entry = mapGet(compiler->vm->core_libs, VAR_OBJ(module));
@@ -2275,11 +2348,11 @@ static inline Script* compilerImport(Compiler* compiler) {
 
   // Get the script (from core libs or vm's cache or compile new one).
   // And push it on the stack.
-  if (match(compiler, TK_NAME)) { //< Core library.
+  if (match(compiler, TK_NAME)) {  //< Core library.
     return importCoreLib(compiler, compiler->previous.start,
                          compiler->previous.length);
 
-  } else if (match(compiler, TK_STRING)) { //< Local library.
+  } else if (match(compiler, TK_STRING)) {  //< Local library.
     Var var_path = compiler->previous.value;
     ASSERT(IS_OBJ_TYPE(var_path, OBJ_STRING), OOPS);
     String* path = (String*)AS_OBJ(var_path);
@@ -2295,8 +2368,8 @@ static inline Script* compilerImport(Compiler* compiler) {
 // exists in the globals it'll add a variable to the globals entry and return.
 // But If the name is predefined function (cannot be modified). It'll set error
 // and return -1.
-static int compilerImportName(Compiler* compiler, int line,
-                              const char* name, uint32_t length) {
+static int compilerImportName(Compiler* compiler, int line, const char* name,
+                              uint32_t length) {
   ASSERT(compiler->scope_depth == DEPTH_GLOBAL, OOPS);
 
   NameSearchResult result = compilerSearchName(compiler, name, length);
@@ -2322,9 +2395,8 @@ static int compilerImportName(Compiler* compiler, int line,
 
 // This will called by the compilerImportAll() function to import a single
 // entry from the imported script. (could be a function or global variable).
-static void compilerImportSingleEntry(Compiler* compiler,
-                                      const char* name, uint32_t length) {
-
+static void compilerImportSingleEntry(Compiler* compiler, const char* name,
+                                      uint32_t length) {
   // Special names are begins with '$' like function body (only for now).
   // Skip them.
   if (name[0] == '$') return;
@@ -2333,8 +2405,8 @@ static void compilerImportSingleEntry(Compiler* compiler,
   int line = compiler->previous.line;
 
   // Add the name to the **current** script's name buffer.
-  int name_index = (int)scriptAddName(compiler->script, compiler->vm,
-                                      name, length);
+  int name_index =
+      (int)scriptAddName(compiler->script, compiler->vm, name, length);
 
   // Get the function from the script.
   emitOpcode(compiler, OP_GET_ATTRIB_KEEP);
@@ -2348,7 +2420,6 @@ static void compilerImportSingleEntry(Compiler* compiler,
 // Import all from the script, which is also would be at the top of the stack
 // before executing the below instructions.
 static void compilerImportAll(Compiler* compiler, Script* script) {
-
   ASSERT(script != NULL, OOPS);
   ASSERT(compiler->scope_depth == DEPTH_GLOBAL, OOPS);
 
@@ -2401,12 +2472,12 @@ static void compileFromImport(Compiler* compiler) {
       int line = compiler->previous.line;
 
       // Add the name of the symbol to the names buffer.
-      int name_index = (int)scriptAddName(compiler->script, compiler->vm,
-                                          name, length);
+      int name_index =
+          (int)scriptAddName(compiler->script, compiler->vm, name, length);
 
       // Don't pop the lib since it'll be used for the next entry.
       emitOpcode(compiler, OP_GET_ATTRIB_KEEP);
-      emitShort(compiler, name_index); //< Name of the attrib.
+      emitShort(compiler, name_index);  //< Name of the attrib.
 
       // Check if it has an alias.
       if (match(compiler, TK_AS)) {
@@ -2441,7 +2512,6 @@ static void compileRegularImport(Compiler* compiler) {
   ASSERT(compiler->scope_depth == DEPTH_GLOBAL, OOPS);
 
   do {
-
     // Import the library and push it on the stack. If it cannot import,
     // the lib would be null, but we're not terminating here, just continue
     // parsing for cascaded errors.
@@ -2467,7 +2537,6 @@ static void compileRegularImport(Compiler* compiler) {
       // Core libs names are it's module name but for local libs it's optional
       // to define a module name for a script.
       if (lib && lib->module != NULL) {
-
         // Get the variable to bind the imported symbol, if we already have a
         // variable with that name override it, otherwise use a new variable.
         const char* name = lib->module->data;
@@ -2504,19 +2573,17 @@ static void compileExpression(Compiler* compiler) {
 }
 
 static void compileIfStatement(Compiler* compiler, bool elsif) {
-
   skipNewLines(compiler);
-  compileExpression(compiler); //< Condition.
+  compileExpression(compiler);  //< Condition.
   emitOpcode(compiler, OP_JUMP_IF_NOT);
-  int ifpatch = emitShort(compiler, 0xffff); //< Will be patched.
+  int ifpatch = emitShort(compiler, 0xffff);  //< Will be patched.
 
   compileBlockBody(compiler, BLOCK_IF);
 
   if (match(compiler, TK_ELSIF)) {
-
     // Jump pass else.
     emitOpcode(compiler, OP_JUMP);
-    int exit_jump = emitShort(compiler, 0xffff); //< Will be patched.
+    int exit_jump = emitShort(compiler, 0xffff);  //< Will be patched.
 
     // if (false) jump here.
     patchJump(compiler, ifpatch);
@@ -2528,10 +2595,9 @@ static void compileIfStatement(Compiler* compiler, bool elsif) {
     patchJump(compiler, exit_jump);
 
   } else if (match(compiler, TK_ELSE)) {
-
     // Jump pass else.
     emitOpcode(compiler, OP_JUMP);
-    int exit_jump = emitShort(compiler, 0xffff); //< Will be patched.
+    int exit_jump = emitShort(compiler, 0xffff);  //< Will be patched.
 
     patchJump(compiler, ifpatch);
     compileBlockBody(compiler, BLOCK_ELSE);
@@ -2557,9 +2623,9 @@ static void compileWhileStatement(Compiler* compiler) {
   loop.depth = compiler->scope_depth;
   compiler->loop = &loop;
 
-  compileExpression(compiler); //< Condition.
+  compileExpression(compiler);  //< Condition.
   emitOpcode(compiler, OP_JUMP_IF_NOT);
-  int whilepatch = emitShort(compiler, 0xffff); //< Will be patched.
+  int whilepatch = emitShort(compiler, 0xffff);  //< Will be patched.
 
   compileBlockBody(compiler, BLOCK_LOOP);
 
@@ -2588,17 +2654,18 @@ static void compileForStatement(Compiler* compiler) {
   consume(compiler, TK_IN, "Expected 'in' after iterator name.");
 
   // Compile and store sequence.
-  compilerAddVariable(compiler, "@Sequence", 9, iter_line); // Sequence
+  compilerAddVariable(compiler, "@Sequence", 9, iter_line);  // Sequence
   compileExpression(compiler);
 
   // Add iterator to locals. It's an increasing integer indicating that the
   // current loop is nth starting from 0.
-  compilerAddVariable(compiler, "@iterator", 9, iter_line); // Iterator.
+  compilerAddVariable(compiler, "@iterator", 9, iter_line);  // Iterator.
   emitOpcode(compiler, OP_PUSH_0);
 
   // Add the iteration value. It'll be updated to each element in an array of
   // each character in a string etc.
-  compilerAddVariable(compiler, iter_name, iter_len, iter_line); // Iter value.
+  compilerAddVariable(compiler, iter_name, iter_len,
+                      iter_line);  // Iter value.
   emitOpcode(compiler, OP_PUSH_NULL);
 
   // Start the iteration, and check if the sequence is iterable.
@@ -2617,8 +2684,8 @@ static void compileForStatement(Compiler* compiler) {
 
   compileBlockBody(compiler, BLOCK_LOOP);
 
-  emitLoopJump(compiler); //< Loop back to iteration.
-  patchJump(compiler, forpatch); //< Patch exit iteration address.
+  emitLoopJump(compiler);         //< Loop back to iteration.
+  patchJump(compiler, forpatch);  //< Patch exit iteration address.
 
   // Patch break statement.
   for (int i = 0; i < compiler->loop->patch_count; i++) {
@@ -2628,13 +2695,12 @@ static void compileForStatement(Compiler* compiler) {
 
   skipNewLines(compiler);
   consume(compiler, TK_END, "Expected 'end' after statement end.");
-  compilerExitBlock(compiler); //< Iterator scope.
+  compilerExitBlock(compiler);  //< Iterator scope.
 }
 
 // Compiles a statement. Assignment could be an assignment statement or a new
 // variable declaration, which will be handled.
 static void compileStatement(Compiler* compiler) {
-
   // is_temproary will be set to true if the statement is an temporary
   // expression, it'll used to be pop from the stack.
   bool is_temproary = false;
@@ -2653,14 +2719,14 @@ static void compileStatement(Compiler* compiler) {
     }
 
     ASSERT(compiler->loop->patch_count < MAX_BREAK_PATCH,
-      "Too many break statements (" STRINGIFY(MAX_BREAK_PATCH) ")." );
+           "Too many break statements (" STRINGIFY(MAX_BREAK_PATCH) ").");
 
     consumeEndStatement(compiler);
     // Pop all the locals at the loop's body depth.
     compilerPopLocals(compiler, compiler->loop->depth + 1);
 
     emitOpcode(compiler, OP_JUMP);
-    int patch = emitShort(compiler, 0xffff); //< Will be patched.
+    int patch = emitShort(compiler, 0xffff);  //< Will be patched.
     compiler->loop->patches[compiler->loop->patch_count++] = patch;
 
   } else if (match(compiler, TK_CONTINUE)) {
@@ -2676,7 +2742,6 @@ static void compileStatement(Compiler* compiler) {
     emitLoopJump(compiler);
 
   } else if (match(compiler, TK_RETURN)) {
-
     if (compiler->scope_depth == DEPTH_GLOBAL) {
       parseError(compiler, "Invalid 'return' outside a function.");
       return;
@@ -2686,12 +2751,12 @@ static void compileStatement(Compiler* compiler) {
       emitOpcode(compiler, OP_PUSH_NULL);
       emitOpcode(compiler, OP_RETURN);
     } else {
-      compileExpression(compiler); //< Return value is at stack top.
+      compileExpression(compiler);  //< Return value is at stack top.
 
       // Tail call optimization disabled at debug mode.
       if (compiler->options && !compiler->options->debug) {
         if (compiler->is_last_call) {
-          ASSERT(_FN->opcodes.count >= 2, OOPS); // OP_CALL, argc
+          ASSERT(_FN->opcodes.count >= 2, OOPS);  // OP_CALL, argc
           ASSERT(_FN->opcodes.data[_FN->opcodes.count - 2] == OP_CALL, OOPS);
           _FN->opcodes.data[_FN->opcodes.count - 2] = OP_TAIL_CALL;
 
@@ -2737,7 +2802,6 @@ static void compileStatement(Compiler* compiler) {
 // as import statement, function define, and if we're running REPL mode top
 // level expression's evaluated value will be printed.
 static void compileTopLevelStatement(Compiler* compiler) {
-
   // If the statement is call, this will be set to true.
   compiler->is_last_call = false;
 
@@ -2757,8 +2821,9 @@ static void compileTopLevelStatement(Compiler* compiler) {
     compileRegularImport(compiler);
 
   } else if (match(compiler, TK_MODULE)) {
-    parseError(compiler, "Module name must be the first statement "
-                          "of the script.");
+    parseError(compiler,
+               "Module name must be the first statement "
+               "of the script.");
 
   } else {
     compileStatement(compiler);
@@ -2767,12 +2832,11 @@ static void compileTopLevelStatement(Compiler* compiler) {
 
 PkResult compile(PKVM* vm, Script* script, const char* source,
                  const PkCompileOptions* options) {
-
   // Skip utf8 BOM if there is any.
   if (strncmp(source, "\xEF\xBB\xBF", 3) == 0) source += 3;
 
   Compiler _compiler;
-  Compiler* compiler = &_compiler; //< Compiler pointer for quick access.
+  Compiler* compiler = &_compiler;  //< Compiler pointer for quick access.
   compilerInit(compiler, vm, source, script, options);
 
   // If compiling for an imported script the vm->compiler would be the compiler
@@ -2809,7 +2873,6 @@ PkResult compile(PKVM* vm, Script* script, const char* source,
   skipNewLines(compiler);
 
   if (match(compiler, TK_MODULE)) {
-
     // If the script running a REPL or compiled multiple times by hosting
     // application module attribute might already set. In that case make it
     // Compile error.
@@ -2891,7 +2954,6 @@ PkResult pkCompileModule(PKVM* vm, PkHandle* module, PkStringPtr source,
 }
 
 void compilerMarkObjects(PKVM* vm, Compiler* compiler) {
-
   // Mark the script which is currently being compiled.
   markObject(vm, &compiler->script->_super);
 

--- a/src/pk_compiler.h
+++ b/src/pk_compiler.h
@@ -10,9 +10,9 @@
 #include "pk_var.h"
 
 typedef enum {
-  #define OPCODE(name, _, __) OP_##name,
-  #include "pk_opcodes.h"
-  #undef OPCODE
+#define OPCODE(name, _, __) OP_##name,
+#include "pk_opcodes.h"
+#undef OPCODE
 } Opcode;
 
 // Pocketlang compiler is a one pass/single pass compiler, which means it
@@ -37,4 +37,4 @@ PkResult compile(PKVM* vm, Script* script, const char* source,
 // called at the marking phase of vmCollectGarbage().
 void compilerMarkObjects(PKVM* vm, Compiler* compiler);
 
-#endif // COMPILER_H
+#endif  // COMPILER_H

--- a/src/pk_core.c
+++ b/src/pk_core.c
@@ -41,8 +41,8 @@
 static Script* newModuleInternal(PKVM* vm, const char* name);
 
 // The internal function to add global value to a module.
-static void moduleAddGlobalInternal(PKVM* vm, Script* script,
-                                    const char* name, Var value);
+static void moduleAddGlobalInternal(PKVM* vm, Script* script, const char* name,
+                                    Var value);
 
 // The internal function to add functions to a module.
 static void moduleAddFunctionInternal(PKVM* vm, Script* script,
@@ -56,8 +56,8 @@ PkHandle* pkNewModule(PKVM* vm, const char* name) {
 }
 
 // pkModuleAddGlobal implementation (see pocketlang.h for description).
-PK_PUBLIC void pkModuleAddGlobal(PKVM* vm, PkHandle* module,
-                                 const char* name, PkHandle* value) {
+PK_PUBLIC void pkModuleAddGlobal(PKVM* vm, PkHandle* module, const char* name,
+                                 PkHandle* value) {
   __ASSERT(module != NULL, "Argument module was NULL.");
   __ASSERT(value != NULL, "Argument value was NULL.");
   Var scr = module->value;
@@ -76,8 +76,7 @@ void pkModuleAddFunction(PKVM* vm, PkHandle* module, const char* name,
                             NULL /*TODO: Public API for function docstring.*/);
 }
 
-PkHandle* pkGetFunction(PKVM* vm, PkHandle* module,
-                                  const char* name) {
+PkHandle* pkGetFunction(PKVM* vm, PkHandle* module, const char* name) {
   __ASSERT(module != NULL, "Argument module was NULL.");
   Var scr = module->value;
   __ASSERT(IS_OBJ_TYPE(scr, OBJ_SCRIPT), "Given handle is not a module");
@@ -107,35 +106,35 @@ PkHandle* pkGetFunction(PKVM* vm, PkHandle* module,
     return;                    \
   } while (false)
 
-#define RET_ERR(err)           \
-  do {                         \
-    VM_SET_ERROR(vm, err);     \
-    RET(VAR_NULL);             \
-  } while(false)
+#define RET_ERR(err)       \
+  do {                     \
+    VM_SET_ERROR(vm, err); \
+    RET(VAR_NULL);         \
+  } while (false)
 
 // Check for errors in before calling the get arg public api function.
-#define CHECK_GET_ARG_API_ERRORS()                                          \
-  do {                                                                      \
-    __ASSERT(vm->fiber != NULL,                                             \
-             "This function can only be called at runtime.");               \
-    if (arg != 0) {/* If Native setter, the value would be at fiber->ret */ \
-      __ASSERT(arg > 0 && arg <= ARGC, "Invalid argument index.");          \
-    }                                                                       \
-    __ASSERT(value != NULL, "Argument [value] was NULL.");                  \
+#define CHECK_GET_ARG_API_ERRORS()                                           \
+  do {                                                                       \
+    __ASSERT(vm->fiber != NULL,                                              \
+             "This function can only be called at runtime.");                \
+    if (arg != 0) { /* If Native setter, the value would be at fiber->ret */ \
+      __ASSERT(arg > 0 && arg <= ARGC, "Invalid argument index.");           \
+    }                                                                        \
+    __ASSERT(value != NULL, "Argument [value] was NULL.");                   \
   } while (false)
 
 // Set error for incompatible type provided as an argument. (TODO: got type).
-#define ERR_INVALID_ARG_TYPE(m_type)                                        \
-do {                                                                        \
-  if (arg != 0) { /* If Native setter, arg index would be 0. */             \
-    char buff[STR_INT_BUFF_SIZE];                                           \
-    sprintf(buff, "%d", arg);                                               \
-    VM_SET_ERROR(vm, stringFormat(vm, "Expected a '$' at argument $.",      \
-                                      m_type, buff));                       \
-  } else {                                                                  \
-    VM_SET_ERROR(vm, stringFormat(vm, "Expected a '$'.", m_type));          \
-  }                                                                         \
-} while (false)
+#define ERR_INVALID_ARG_TYPE(m_type)                                     \
+  do {                                                                   \
+    if (arg != 0) { /* If Native setter, arg index would be 0. */        \
+      char buff[STR_INT_BUFF_SIZE];                                      \
+      sprintf(buff, "%d", arg);                                          \
+      VM_SET_ERROR(vm, stringFormat(vm, "Expected a '$' at argument $.", \
+                                    m_type, buff));                      \
+    } else {                                                             \
+      VM_SET_ERROR(vm, stringFormat(vm, "Expected a '$'.", m_type));     \
+    }                                                                    \
+  } while (false)
 
 // pkGetArgc implementation (see pocketlang.h for description).
 int pkGetArgc(const PKVM* vm) {
@@ -148,15 +147,17 @@ bool pkCheckArgcRange(PKVM* vm, int argc, int min, int max) {
   ASSERT(min <= max, "invalid argc range (min > max).");
 
   if (argc < min) {
-    char buff[STR_INT_BUFF_SIZE]; sprintf(buff, "%d", min);
-    VM_SET_ERROR(vm, stringFormat(vm, "Expected at least %s argument(s).",
-                                       buff));
+    char buff[STR_INT_BUFF_SIZE];
+    sprintf(buff, "%d", min);
+    VM_SET_ERROR(vm,
+                 stringFormat(vm, "Expected at least %s argument(s).", buff));
     return false;
 
   } else if (argc > max) {
-    char buff[STR_INT_BUFF_SIZE]; sprintf(buff, "%d", max);
-    VM_SET_ERROR(vm, stringFormat(vm, "Expected at most %s argument(s).",
-                                       buff));
+    char buff[STR_INT_BUFF_SIZE];
+    sprintf(buff, "%d", max);
+    VM_SET_ERROR(vm,
+                 stringFormat(vm, "Expected at most %s argument(s).", buff));
     return false;
   }
 
@@ -251,9 +252,10 @@ bool pkGetArgValue(PKVM* vm, int arg, PkVarType type, PkVar* value) {
 
   Var val = ARG(arg);
   if (pkGetValueType((PkVar)&val) != type) {
-    char buff[STR_INT_BUFF_SIZE]; sprintf(buff, "%d", arg);
+    char buff[STR_INT_BUFF_SIZE];
+    sprintf(buff, "%d", arg);
     VM_SET_ERROR(vm, stringFormat(vm, "Expected a $ at argument $.",
-                 getPkVarTypeName(type), buff));
+                                  getPkVarTypeName(type), buff));
     return false;
   }
 
@@ -262,19 +264,13 @@ bool pkGetArgValue(PKVM* vm, int arg, PkVarType type, PkVar* value) {
 }
 
 // pkReturnNull implementation (see pocketlang.h for description).
-void pkReturnNull(PKVM* vm) {
-  RET(VAR_NULL);
-}
+void pkReturnNull(PKVM* vm) { RET(VAR_NULL); }
 
 // pkReturnBool implementation (see pocketlang.h for description).
-void pkReturnBool(PKVM* vm, bool value) {
-  RET(VAR_BOOL(value));
-}
+void pkReturnBool(PKVM* vm, bool value) { RET(VAR_BOOL(value)); }
 
 // pkReturnNumber implementation (see pocketlang.h for description).
-void pkReturnNumber(PKVM* vm, double value) {
-  RET(VAR_NUM(value));
-}
+void pkReturnNumber(PKVM* vm, double value) { RET(VAR_NUM(value)); }
 
 // pkReturnString implementation (see pocketlang.h for description).
 void pkReturnString(PKVM* vm, const char* value) {
@@ -287,14 +283,10 @@ void pkReturnStringLength(PKVM* vm, const char* value, size_t length) {
 }
 
 // pkReturnValue implementation (see pocketlang.h for description).
-void pkReturnValue(PKVM* vm, PkVar value) {
-  RET(*(Var*)value);
-}
+void pkReturnValue(PKVM* vm, PkVar value) { RET(*(Var*)value); }
 
 // pkReturnHandle implementation (see pocketlang.h for description).
-void pkReturnHandle(PKVM* vm, PkHandle* handle) {
-  RET(handle->value);
-}
+void pkReturnHandle(PKVM* vm, PkHandle* handle) { RET(handle->value); }
 
 // pkReturnInstNative implementation (see pocketlang.h for description).
 void pkReturnInstNative(PKVM* vm, void* data, uint32_t id) {
@@ -350,7 +342,7 @@ static inline bool isInteger(Var var, int64_t* value) {
     // TODO: check if the number is larger for a 64 bit integer.
     if (floor(number) == number) {
       ASSERT(INT64_MIN <= number && number <= INT64_MAX,
-        "TODO: Large numbers haven't handled yet. Please report!");
+             "TODO: Large numbers haven't handled yet. Please report!");
       *value = (int64_t)(number);
       return true;
     }
@@ -392,18 +384,20 @@ static inline bool validateIndex(PKVM* vm, int64_t index, uint32_t size,
     Var var = ARG(arg);                                                      \
     ASSERT(arg > 0 && arg <= ARGC, OOPS);                                    \
     if (!IS_OBJ(var) || AS_OBJ(var)->type != m_type) {                       \
-      char buff[12]; sprintf(buff, "%d", arg);                               \
-      VM_SET_ERROR(vm, stringFormat(vm, "Expected a " m_name                 \
-                   " at argument $.", buff, false));                         \
+      char buff[12];                                                         \
+      sprintf(buff, "%d", arg);                                              \
+      VM_SET_ERROR(                                                          \
+          vm, stringFormat(vm, "Expected a " m_name " at argument $.", buff, \
+                           false));                                          \
     }                                                                        \
     *value = (m_class*)AS_OBJ(var);                                          \
     return true;                                                             \
-   }
- VALIDATE_ARG_OBJ(String, OBJ_STRING, "string")
- VALIDATE_ARG_OBJ(List, OBJ_LIST, "list")
- VALIDATE_ARG_OBJ(Map, OBJ_MAP, "map")
- VALIDATE_ARG_OBJ(Function, OBJ_FUNC, "function")
- VALIDATE_ARG_OBJ(Fiber, OBJ_FIBER, "fiber")
+  }
+VALIDATE_ARG_OBJ(String, OBJ_STRING, "string")
+VALIDATE_ARG_OBJ(List, OBJ_LIST, "list")
+VALIDATE_ARG_OBJ(Map, OBJ_MAP, "map")
+VALIDATE_ARG_OBJ(Function, OBJ_FUNC, "function")
+VALIDATE_ARG_OBJ(Fiber, OBJ_FIBER, "fiber")
 
 /*****************************************************************************/
 /* SHARED FUNCTIONS                                                          */
@@ -411,14 +405,14 @@ static inline bool validateIndex(PKVM* vm, int64_t index, uint32_t size,
 
 // findBuiltinFunction implementation (see core.h for description).
 int findBuiltinFunction(const PKVM* vm, const char* name, uint32_t length) {
-   for (uint32_t i = 0; i < vm->builtins_count; i++) {
-     if (length == vm->builtins[i].length &&
-       strncmp(name, vm->builtins[i].name, length) == 0) {
-       return i;
-     }
-   }
-   return -1;
- }
+  for (uint32_t i = 0; i < vm->builtins_count; i++) {
+    if (length == vm->builtins[i].length &&
+        strncmp(name, vm->builtins[i].name, length) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
 
 // getBuiltinFunction implementation (see core.h for description).
 Function* getBuiltinFunction(const PKVM* vm, int index) {
@@ -445,16 +439,14 @@ Script* getCoreLib(const PKVM* vm, String* name) {
 /*****************************************************************************/
 
 DEF(coreTypeName,
-  "type_name(value:var) -> string\n"
-  "Returns the type name of the of the value.") {
-
+    "type_name(value:var) -> string\n"
+    "Returns the type name of the of the value.") {
   RET(VAR_OBJ(newString(vm, varTypeName(ARG(1)))));
 }
 
 DEF(coreHelp,
-  "help([fn]) -> null\n"
-  "This will write an error message to stdout and return null.") {
-
+    "help([fn]) -> null\n"
+    "This will write an error message to stdout and return null.") {
   int argc = ARGC;
   if (argc != 0 && argc != 1) {
     RET_ERR(newString(vm, "Invalid argument count."));
@@ -485,10 +477,9 @@ DEF(coreHelp,
 }
 
 DEF(coreAssert,
-  "assert(condition:bool [, msg:string]) -> void\n"
-  "If the condition is false it'll terminate the current fiber with the "
-  "optional error message") {
-
+    "assert(condition:bool [, msg:string]) -> void\n"
+    "If the condition is false it'll terminate the current fiber with the "
+    "optional error message") {
   int argc = ARGC;
   if (argc != 1 && argc != 2) {
     RET_ERR(newString(vm, "Invalid argument count."));
@@ -513,9 +504,8 @@ DEF(coreAssert,
 }
 
 DEF(coreBin,
-  "bin(value:num) -> string\n"
-  "Returns as a binary value string with '0x' prefix.") {
-
+    "bin(value:num) -> string\n"
+    "Returns as a binary value string with '0x' prefix.") {
   int64_t value;
   if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
 
@@ -525,7 +515,7 @@ DEF(coreBin,
   if (negative) value = -value;
 
   char* ptr = buff + STR_BIN_BUFF_SIZE - 1;
-  *ptr-- = '\0'; // NULL byte at the end of the string.
+  *ptr-- = '\0';  // NULL byte at the end of the string.
 
   if (value != 0) {
     while (value > 0) {
@@ -536,7 +526,8 @@ DEF(coreBin,
     *ptr-- = '0';
   }
 
-  *ptr-- = 'b'; *ptr-- = '0';
+  *ptr-- = 'b';
+  *ptr-- = '0';
   if (negative) *ptr-- = '-';
 
   uint32_t length = (uint32_t)((buff + STR_BIN_BUFF_SIZE - 1) - (ptr + 1));
@@ -544,9 +535,8 @@ DEF(coreBin,
 }
 
 DEF(coreHex,
-  "hex(value:num) -> string\n"
-  "Returns as a hexadecimal value string with '0x' prefix.") {
-
+    "hex(value:num) -> string\n"
+    "Returns as a hexadecimal value string with '0x' prefix.") {
   int64_t value;
   if (!validateInteger(vm, ARG(1), &value, "Argument 1")) return;
 
@@ -554,7 +544,8 @@ DEF(coreHex,
 
   char* ptr = buff;
   if (value < 0) *ptr++ = '-';
-  *ptr++ = '0'; *ptr++ = 'x';
+  *ptr++ = '0';
+  *ptr++ = 'x';
 
   if (value > UINT32_MAX || value < -(int64_t)(UINT32_MAX)) {
     VM_SET_ERROR(vm, newString(vm, "Integer is too large."));
@@ -566,19 +557,19 @@ DEF(coreHex,
   uint32_t _x = (uint32_t)((value < 0) ? -value : value);
   int length = sprintf(ptr, "%x", _x);
 
-  RET(VAR_OBJ(newStringLength(vm, buff,
-    (uint32_t)((ptr + length) - (char*)(buff)))));
+  RET(VAR_OBJ(
+      newStringLength(vm, buff, (uint32_t)((ptr + length) - (char*)(buff)))));
 }
 
 DEF(coreYield,
-  "yield([value]) -> var\n"
-  "Return the current function with the yield [value] to current running "
-  "fiber. If the fiber is resumed, it'll run from the next statement of the "
-  "yield() call. If the fiber resumed with with a value, the return value of "
-  "the yield() would be that value otherwise null.") {
-
+    "yield([value]) -> var\n"
+    "Return the current function with the yield [value] to current running "
+    "fiber. If the fiber is resumed, it'll run from the next statement of the "
+    "yield() call. If the fiber resumed with with a value, the return value "
+    "of "
+    "the yield() would be that value otherwise null.") {
   int argc = ARGC;
-  if (argc > 1) { // yield() or yield(val).
+  if (argc > 1) {  // yield() or yield(val).
     RET_ERR(newString(vm, "Invalid argument count."));
   }
 
@@ -586,17 +577,15 @@ DEF(coreYield,
 }
 
 DEF(coreToString,
-  "to_string(value:var) -> string\n"
-  "Returns the string representation of the value.") {
-
+    "to_string(value:var) -> string\n"
+    "Returns the string representation of the value.") {
   RET(VAR_OBJ(toString(vm, ARG(1))));
 }
 
 DEF(corePrint,
-  "print(...) -> void\n"
-  "Write each argument as space seperated, to the stdout and ends with a "
-  "newline.") {
-
+    "print(...) -> void\n"
+    "Write each argument as space seperated, to the stdout and ends with a "
+    "newline.") {
   // If the host application doesn't provide any write function, discard the
   // output.
   if (vm->config.write_fn == NULL) return;
@@ -610,10 +599,9 @@ DEF(corePrint,
 }
 
 DEF(coreInput,
-  "input([msg:var]) -> string\n"
-  "Read a line from stdin and returns it without the line ending. Accepting "
-  "an optional argument [msg] and prints it before reading.") {
-
+    "input([msg:var]) -> string\n"
+    "Read a line from stdin and returns it without the line ending. Accepting "
+    "an optional argument [msg] and prints it before reading.") {
   int argc = ARGC;
   if (argc != 1 && argc != 2) {
     RET_ERR(newString(vm, "Invalid argument count."));
@@ -633,12 +621,11 @@ DEF(coreInput,
 }
 
 DEF(coreExit,
-  "exit([value:num]) -> null\n"
-  "Exit the process with an optional exit code provided by the argument "
-  "[value]. The default exit code is would be 0.") {
-
+    "exit([value:num]) -> null\n"
+    "Exit the process with an optional exit code provided by the argument "
+    "[value]. The default exit code is would be 0.") {
   int argc = ARGC;
-  if (argc > 1) { // exit() or exit(val).
+  if (argc > 1) {  // exit() or exit(val).
     RET_ERR(newString(vm, "Invalid argument count."));
   }
 
@@ -655,11 +642,10 @@ DEF(coreExit,
 // -----------------
 
 DEF(coreStrSub,
-  "str_sub(str:string, pos:num, len:num) -> string\n"
-  "Returns a substring from a given string supplied. In addition, "
-  "the position and length of the substring are provided when this "
-  "function is called. For example: `str_sub(str, pos, len)`.") {
-
+    "str_sub(str:string, pos:num, len:num) -> string\n"
+    "Returns a substring from a given string supplied. In addition, "
+    "the position and length of the substring are provided when this "
+    "function is called. For example: `str_sub(str, pos, len)`.") {
   String* str;
   int64_t pos, len;
 
@@ -680,9 +666,8 @@ DEF(coreStrSub,
 }
 
 DEF(coreStrChr,
-  "str_chr(value:num) -> string\n"
-  "Returns the ASCII string value of the integer argument.") {
-
+    "str_chr(value:num) -> string\n"
+    "Returns the ASCII string value of the integer argument.") {
   int64_t num;
   if (!validateInteger(vm, ARG(1), &num, "Argument 1")) return;
 
@@ -695,9 +680,8 @@ DEF(coreStrChr,
 }
 
 DEF(coreStrOrd,
-  "str_ord(value:string) -> num\n"
-  "Returns integer value of the given ASCII character.") {
-
+    "str_ord(value:string) -> num\n"
+    "Returns integer value of the given ASCII character.") {
   String* c;
   if (!validateArgString(vm, 1, &c)) return;
   if (c->length != 1) {
@@ -712,9 +696,8 @@ DEF(coreStrOrd,
 // ---------------
 
 DEF(coreListAppend,
-  "list_append(self:List, value:var) -> List\n"
-  "Append the [value] to the list [self] and return the list.") {
-
+    "list_append(self:List, value:var) -> List\n"
+    "Append the [value] to the list [self] and return the list.") {
   List* list;
   if (!validateArgList(vm, 1, &list)) return;
   Var elem = ARG(2);
@@ -727,10 +710,9 @@ DEF(coreListAppend,
 // --------------
 
 DEF(coreMapRemove,
-  "map_remove(self:map, key:var) -> var\n"
-  "Remove the [key] from the map [self] and return it's value if the key "
-  "exists, otherwise it'll return null.") {
-
+    "map_remove(self:map, key:var) -> var\n"
+    "Remove the [key] from the map [self] and return it's value if the key "
+    "exists, otherwise it'll return null.") {
   Map* map;
   if (!validateArgMap(vm, 1, &map)) return;
   Var key = ARG(2);
@@ -744,7 +726,6 @@ DEF(coreMapRemove,
 
 // Create a module and add it to the vm's core modules, returns the script.
 static Script* newModuleInternal(PKVM* vm, const char* name) {
-
   // Create a new Script for the module.
   String* _name = newString(vm, name);
   vmPushTempRef(vm, &_name->_super);
@@ -752,13 +733,14 @@ static Script* newModuleInternal(PKVM* vm, const char* name) {
   // Check if any module with the same name already exists and assert to the
   // hosting application.
   if (!IS_UNDEF(mapGet(vm->core_libs, VAR_OBJ(_name)))) {
-    vmPopTempRef(vm); // _name
-    __ASSERT(false, stringFormat(vm,
-             "A module named '$' already exists", name)->data);
+    vmPopTempRef(vm);  // _name
+    __ASSERT(
+        false,
+        stringFormat(vm, "A module named '$' already exists", name)->data);
   }
 
   Script* scr = newScript(vm, _name, true);
-  vmPopTempRef(vm); // _name
+  vmPopTempRef(vm);  // _name
 
   // Add the script to core_libs.
   vmPushTempRef(vm, &scr->_super);
@@ -774,21 +756,26 @@ static inline void assertModuleNameDef(PKVM* vm, Script* script,
                                        const char* name) {
   // Check if function with the same name already exists.
   if (scriptGetFunc(script, name, (uint32_t)strlen(name)) != -1) {
-    __ASSERT(false, stringFormat(vm, "A function named '$' already esists "
-      "on module '@'", name, script->module)->data);
+    __ASSERT(false, stringFormat(vm,
+                                 "A function named '$' already esists "
+                                 "on module '@'",
+                                 name, script->module)
+                        ->data);
   }
 
   // Check if a global variable with the same name already exists.
   if (scriptGetGlobals(script, name, (uint32_t)strlen(name)) != -1) {
-    __ASSERT(false, stringFormat(vm, "A global variable named '$' already "
-      "esists on module '@'", name, script->module)->data);
+    __ASSERT(false, stringFormat(vm,
+                                 "A global variable named '$' already "
+                                 "esists on module '@'",
+                                 name, script->module)
+                        ->data);
   }
 }
 
 // The internal function to add global value to a module.
-static void moduleAddGlobalInternal(PKVM* vm, Script* script,
-                                    const char* name, Var value) {
-
+static void moduleAddGlobalInternal(PKVM* vm, Script* script, const char* name,
+                                    Var value) {
   // Ensure the name isn't defined already.
   assertModuleNameDef(vm, script, name);
 
@@ -800,12 +787,11 @@ static void moduleAddGlobalInternal(PKVM* vm, Script* script,
 static void moduleAddFunctionInternal(PKVM* vm, Script* script,
                                       const char* name, pkNativeFn fptr,
                                       int arity, const char* docstring) {
-
   // Ensure the name isn't predefined.
   assertModuleNameDef(vm, script, name);
 
-  Function* fn = newFunction(vm, name, (int)strlen(name),
-                             script, true, docstring);
+  Function* fn =
+      newFunction(vm, name, (int)strlen(name), script, true, docstring);
   fn->native = fptr;
   fn->arity = arity;
 }
@@ -816,16 +802,14 @@ static void moduleAddFunctionInternal(PKVM* vm, Script* script,
 // -----------------------
 
 DEF(stdLangClock,
-  "clock() -> num\n"
-  "Returns the number of seconds since the application started") {
-
+    "clock() -> num\n"
+    "Returns the number of seconds since the application started") {
   RET(VAR_NUM((double)clock() / CLOCKS_PER_SEC));
 }
 
 DEF(stdLangGC,
-  "gc() -> num\n"
-  "Trigger garbage collection and return the amount of bytes cleaned.") {
-
+    "gc() -> num\n"
+    "Trigger garbage collection and return the amount of bytes cleaned.") {
   size_t bytes_before = vm->bytes_allocated;
   vmCollectGarbage(vm);
   size_t garbage = bytes_before - vm->bytes_allocated;
@@ -833,9 +817,8 @@ DEF(stdLangGC,
 }
 
 DEF(stdLangDisas,
-  "disas(fn:Function) -> String\n"
-  "Returns the disassembled opcode of the function [fn].") {
-
+    "disas(fn:Function) -> String\n"
+    "Returns the disassembled opcode of the function [fn].") {
   Function* fn;
   if (!validateArgFunction(vm, 1, &fn)) return;
 
@@ -850,23 +833,21 @@ DEF(stdLangDisas,
 
 #ifdef DEBUG
 DEF(stdLangDebugBreak,
-  "debug_break() -> null\n"
-  "A debug function for development (will be removed).") {
-
+    "debug_break() -> null\n"
+    "A debug function for development (will be removed).") {
   DEBUG_BREAK();
 }
 #endif
 
 DEF(stdLangWrite,
-  "write(...) -> null\n"
-  "Write function, just like print function but it wont put space between"
-  "args and write a new line at the end.") {
-
+    "write(...) -> null\n"
+    "Write function, just like print function but it wont put space between"
+    "args and write a new line at the end.") {
   // If the host application doesn't provide any write function, discard the
   // output.
   if (vm->config.write_fn == NULL) return;
 
-  String* str; //< Will be cleaned by garbage collector;
+  String* str;  //< Will be cleaned by garbage collector;
 
   for (int i = 1; i <= ARGC; i++) {
     Var arg = ARG(i);
@@ -884,64 +865,54 @@ DEF(stdLangWrite,
 // 'math' library methods.
 // -----------------------
 
-DEF(stdMathFloor,
-  "floor(value:num) -> num\n") {
-
+DEF(stdMathFloor, "floor(value:num) -> num\n") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(floor(num)));
 }
 
-DEF(stdMathCeil,
-  "ceil(value:num) -> num\n") {
-
+DEF(stdMathCeil, "ceil(value:num) -> num\n") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(ceil(num)));
 }
 
-DEF(stdMathPow,
-  "pow(value:num) -> num\n") {
-
+DEF(stdMathPow, "pow(value:num) -> num\n") {
   double num, ex;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   if (!validateNumeric(vm, ARG(2), &ex, "Argument 2")) return;
   RET(VAR_NUM(pow(num, ex)));
 }
 
-DEF(stdMathSqrt,
-  "sqrt(value:num) -> num\n") {
-
+DEF(stdMathSqrt, "sqrt(value:num) -> num\n") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(sqrt(num)));
 }
 
-DEF(stdMathAbs,
-  "abs(value:num) -> num\n") {
-
+DEF(stdMathAbs, "abs(value:num) -> num\n") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   if (num < 0) num = -num;
   RET(VAR_NUM(num));
 }
 
-DEF(stdMathSign,
-  "sign(value:num) -> num\n") {
-
+DEF(stdMathSign, "sign(value:num) -> num\n") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
-  if (num < 0) num = -1;
-  else if (num > 0) num = +1;
-  else num = 0;
+  if (num < 0)
+    num = -1;
+  else if (num > 0)
+    num = +1;
+  else
+    num = 0;
   RET(VAR_NUM(num));
 }
 
 DEF(stdMathHash,
-  "hash(value:var) -> num\n"
-  "Return the hash value of the variable, if it's not hashable it'll "
-  "return null.") {
-
+    "hash(value:var) -> num\n"
+    "Return the hash value of the variable, if it's not hashable it'll "
+    "return null.") {
   if (IS_OBJ(ARG(1))) {
     if (!isObjectHashable(AS_OBJ(ARG(1))->type)) {
       RET(VAR_NULL);
@@ -951,67 +922,62 @@ DEF(stdMathHash,
 }
 
 DEF(stdMathSine,
-  "sin(rad:num) -> num\n"
-  "Return the sine value of the argument [rad] which is an angle expressed "
-  "in radians.") {
-
+    "sin(rad:num) -> num\n"
+    "Return the sine value of the argument [rad] which is an angle expressed "
+    "in radians.") {
   double rad;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(sin(rad)));
 }
 
 DEF(stdMathCosine,
-  "cos(rad:num) -> num\n"
-  "Return the cosine value of the argument [rad] which is an angle expressed "
-  "in radians.") {
-
+    "cos(rad:num) -> num\n"
+    "Return the cosine value of the argument [rad] which is an angle "
+    "expressed "
+    "in radians.") {
   double rad;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(cos(rad)));
 }
 
 DEF(stdMathTangent,
-  "tan(rad:num) -> num\n"
-  "Return the tangent value of the argument [rad] which is an angle expressed "
-  "in radians.") {
-
+    "tan(rad:num) -> num\n"
+    "Return the tangent value of the argument [rad] which is an angle "
+    "expressed "
+    "in radians.") {
   double rad;
   if (!validateNumeric(vm, ARG(1), &rad, "Argument 1")) return;
   RET(VAR_NUM(tan(rad)));
 }
 
 DEF(stdMathSinh,
-  "sinh(val) -> val\n"
-  "Return the hyperbolic sine value of the argument [val].") {
-
+    "sinh(val) -> val\n"
+    "Return the hyperbolic sine value of the argument [val].") {
   double val;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(sinh(val)));
 }
 
 DEF(stdMathCosh,
-  "cosh(val) -> val\n"
-  "Return the hyperbolic cosine value of the argument [val].") {
-
+    "cosh(val) -> val\n"
+    "Return the hyperbolic cosine value of the argument [val].") {
   double val;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(cosh(val)));
 }
 
 DEF(stdMathTanh,
-  "tanh(val) -> val\n"
-  "Return the hyperbolic tangent value of the argument [val].") {
-
+    "tanh(val) -> val\n"
+    "Return the hyperbolic tangent value of the argument [val].") {
   double val;
   if (!validateNumeric(vm, ARG(1), &val, "Argument 1")) return;
   RET(VAR_NUM(tanh(val)));
 }
 
 DEF(stdMathArcSine,
-  "asin(num) -> num\n"
-  "Return the arcsine value of the argument [num] which is an angle "
-  "expressed in radians.") {
-
+    "asin(num) -> num\n"
+    "Return the arcsine value of the argument [num] which is an angle "
+    "expressed in radians.") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
 
@@ -1023,10 +989,9 @@ DEF(stdMathArcSine,
 }
 
 DEF(stdMathArcCosine,
-  "acos(num) -> num\n"
-  "Return the arc cosine value of the argument [num] which is "
-  "an angle expressed in radians.") {
-
+    "acos(num) -> num\n"
+    "Return the arc cosine value of the argument [num] which is "
+    "an angle expressed in radians.") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
 
@@ -1038,28 +1003,25 @@ DEF(stdMathArcCosine,
 }
 
 DEF(stdMathArcTangent,
-  "atan(num) -> num\n"
-  "Return the arc tangent value of the argument [num] which is "
-  "an angle expressed in radians.") {
-
+    "atan(num) -> num\n"
+    "Return the arc tangent value of the argument [num] which is "
+    "an angle expressed in radians.") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(atan(num)));
 }
 
 DEF(stdMathLog10,
-  "log10(value:num) -> num\n"
-  "Return the logarithm to base 10 of argument [value]") {
-
+    "log10(value:num) -> num\n"
+    "Return the logarithm to base 10 of argument [value]") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(log10(num)));
 }
 
 DEF(stdMathRound,
-  "round(value:num) -> num\n"
-  "Round to nearest integer, away from zero and return the number.") {
-
+    "round(value:num) -> num\n"
+    "Round to nearest integer, away from zero and return the number.") {
   double num;
   if (!validateNumeric(vm, ARG(1), &num, "Argument 1")) return;
   RET(VAR_NUM(round(num)));
@@ -1069,21 +1031,19 @@ DEF(stdMathRound,
 // -----------------------
 
 DEF(stdFiberNew,
-  "new(fn:Function) -> fiber\n"
-  "Create and return a new fiber from the given function [fn].") {
-
+    "new(fn:Function) -> fiber\n"
+    "Create and return a new fiber from the given function [fn].") {
   Function* fn;
   if (!validateArgFunction(vm, 1, &fn)) return;
   RET(VAR_OBJ(newFiber(vm, fn)));
 }
 
 DEF(stdFiberRun,
-  "run(fb:Fiber, ...) -> var\n"
-  "Runs the fiber's function with the provided arguments and returns it's "
-  "return value or the yielded value if it's yielded.") {
-
+    "run(fb:Fiber, ...) -> var\n"
+    "Runs the fiber's function with the provided arguments and returns it's "
+    "return value or the yielded value if it's yielded.") {
   int argc = ARGC;
-  if (argc == 0) // Missing the fiber argument.
+  if (argc == 0)  // Missing the fiber argument.
     RET_ERR(newString(vm, "Missing argument - fiber."));
 
   Fiber* fb;
@@ -1105,14 +1065,13 @@ DEF(stdFiberRun,
 }
 
 DEF(stdFiberResume,
-  "fiber_resume(fb:Fiber) -> var\n"
-  "Resumes a yielded function from a previous call of fiber_run() function. "
-  "Return it's return value or the yielded value if it's yielded.") {
-
+    "fiber_resume(fb:Fiber) -> var\n"
+    "Resumes a yielded function from a previous call of fiber_run() function. "
+    "Return it's return value or the yielded value if it's yielded.") {
   int argc = ARGC;
-  if (argc == 0) // Missing the fiber argument.
+  if (argc == 0)  // Missing the fiber argument.
     RET_ERR(newString(vm, "Expected at least 1 argument(s)."));
-  if (argc > 2) // Can only accept 1 argument for resume.
+  if (argc > 2)  // Can only accept 1 argument for resume.
     RET_ERR(newString(vm, "Expected at most 2 argument(s)."));
 
   Fiber* fb;
@@ -1143,7 +1102,6 @@ static void initializeBuiltinFN(PKVM* vm, BuiltinFn* bfn, const char* name,
 }
 
 void initializeCore(PKVM* vm) {
-
 #define INITIALIZE_BUILTIN_FN(name, fn, argc)                        \
   initializeBuiltinFN(vm, &vm->builtins[vm->builtins_count++], name, \
                       (int)strlen(name), argc, fn, DOCSTRING(fn));
@@ -1152,64 +1110,64 @@ void initializeCore(PKVM* vm) {
   moduleAddFunctionInternal(vm, module, name, fn, argc, DOCSTRING(fn))
 
   // Initialize builtin functions.
-  INITIALIZE_BUILTIN_FN("type_name",   coreTypeName,   1);
+  INITIALIZE_BUILTIN_FN("type_name", coreTypeName, 1);
 
   // TODO: Add is keyword with modules for builtin types.
   // ex: val is Num; val is null; val is List; val is Range
   //     List.append(l, e) # List is implicitly imported core module.
   //     String.lower(s)
 
-  INITIALIZE_BUILTIN_FN("help",        coreHelp,      -1);
-  INITIALIZE_BUILTIN_FN("assert",      coreAssert,    -1);
-  INITIALIZE_BUILTIN_FN("bin",         coreBin,        1);
-  INITIALIZE_BUILTIN_FN("hex",         coreHex,        1);
-  INITIALIZE_BUILTIN_FN("yield",       coreYield,     -1);
-  INITIALIZE_BUILTIN_FN("to_string",   coreToString,   1);
-  INITIALIZE_BUILTIN_FN("print",       corePrint,     -1);
-  INITIALIZE_BUILTIN_FN("input",       coreInput,     -1);
-  INITIALIZE_BUILTIN_FN("exit",        coreExit,      -1);
+  INITIALIZE_BUILTIN_FN("help", coreHelp, -1);
+  INITIALIZE_BUILTIN_FN("assert", coreAssert, -1);
+  INITIALIZE_BUILTIN_FN("bin", coreBin, 1);
+  INITIALIZE_BUILTIN_FN("hex", coreHex, 1);
+  INITIALIZE_BUILTIN_FN("yield", coreYield, -1);
+  INITIALIZE_BUILTIN_FN("to_string", coreToString, 1);
+  INITIALIZE_BUILTIN_FN("print", corePrint, -1);
+  INITIALIZE_BUILTIN_FN("input", coreInput, -1);
+  INITIALIZE_BUILTIN_FN("exit", coreExit, -1);
 
   // String functions.
-  INITIALIZE_BUILTIN_FN("str_sub",     coreStrSub,     3);
-  INITIALIZE_BUILTIN_FN("str_chr",     coreStrChr,     1);
-  INITIALIZE_BUILTIN_FN("str_ord",     coreStrOrd,     1);
+  INITIALIZE_BUILTIN_FN("str_sub", coreStrSub, 3);
+  INITIALIZE_BUILTIN_FN("str_chr", coreStrChr, 1);
+  INITIALIZE_BUILTIN_FN("str_ord", coreStrOrd, 1);
 
   // List functions.
   INITIALIZE_BUILTIN_FN("list_append", coreListAppend, 2);
 
   // Map functions.
-  INITIALIZE_BUILTIN_FN("map_remove",  coreMapRemove,  2);
+  INITIALIZE_BUILTIN_FN("map_remove", coreMapRemove, 2);
 
   // Core Modules /////////////////////////////////////////////////////////////
 
   Script* lang = newModuleInternal(vm, "lang");
-  MODULE_ADD_FN(lang, "clock", stdLangClock,  0);
-  MODULE_ADD_FN(lang, "gc",    stdLangGC,     0);
-  MODULE_ADD_FN(lang, "disas", stdLangDisas,  1);
+  MODULE_ADD_FN(lang, "clock", stdLangClock, 0);
+  MODULE_ADD_FN(lang, "gc", stdLangGC, 0);
+  MODULE_ADD_FN(lang, "disas", stdLangDisas, 1);
   MODULE_ADD_FN(lang, "write", stdLangWrite, -1);
 #ifdef DEBUG
   MODULE_ADD_FN(lang, "debug_break", stdLangDebugBreak, 0);
 #endif
 
   Script* math = newModuleInternal(vm, "math");
-  MODULE_ADD_FN(math, "floor", stdMathFloor,       1);
-  MODULE_ADD_FN(math, "ceil",  stdMathCeil,        1);
-  MODULE_ADD_FN(math, "pow",   stdMathPow,         2);
-  MODULE_ADD_FN(math, "sqrt",  stdMathSqrt,        1);
-  MODULE_ADD_FN(math, "abs",   stdMathAbs,         1);
-  MODULE_ADD_FN(math, "sign",  stdMathSign,        1);
-  MODULE_ADD_FN(math, "hash",  stdMathHash,        1);
-  MODULE_ADD_FN(math, "sin",   stdMathSine,        1);
-  MODULE_ADD_FN(math, "cos",   stdMathCosine,      1);
-  MODULE_ADD_FN(math, "tan",   stdMathTangent,     1);
-  MODULE_ADD_FN(math, "sinh",  stdMathSinh,        1);
-  MODULE_ADD_FN(math, "cosh",  stdMathCosh,        1);
-  MODULE_ADD_FN(math, "tanh",  stdMathTanh,        1);
-  MODULE_ADD_FN(math, "asin",  stdMathArcSine,     1);
-  MODULE_ADD_FN(math, "acos",  stdMathArcCosine,   1);
-  MODULE_ADD_FN(math, "atan",  stdMathArcTangent,  1);
-  MODULE_ADD_FN(math, "log10", stdMathLog10,       1);
-  MODULE_ADD_FN(math, "round", stdMathRound,       1);
+  MODULE_ADD_FN(math, "floor", stdMathFloor, 1);
+  MODULE_ADD_FN(math, "ceil", stdMathCeil, 1);
+  MODULE_ADD_FN(math, "pow", stdMathPow, 2);
+  MODULE_ADD_FN(math, "sqrt", stdMathSqrt, 1);
+  MODULE_ADD_FN(math, "abs", stdMathAbs, 1);
+  MODULE_ADD_FN(math, "sign", stdMathSign, 1);
+  MODULE_ADD_FN(math, "hash", stdMathHash, 1);
+  MODULE_ADD_FN(math, "sin", stdMathSine, 1);
+  MODULE_ADD_FN(math, "cos", stdMathCosine, 1);
+  MODULE_ADD_FN(math, "tan", stdMathTangent, 1);
+  MODULE_ADD_FN(math, "sinh", stdMathSinh, 1);
+  MODULE_ADD_FN(math, "cosh", stdMathCosh, 1);
+  MODULE_ADD_FN(math, "tanh", stdMathTanh, 1);
+  MODULE_ADD_FN(math, "asin", stdMathArcSine, 1);
+  MODULE_ADD_FN(math, "acos", stdMathArcCosine, 1);
+  MODULE_ADD_FN(math, "atan", stdMathArcTangent, 1);
+  MODULE_ADD_FN(math, "log10", stdMathLog10, 1);
+  MODULE_ADD_FN(math, "round", stdMathRound, 1);
 
   // Note that currently it's mutable (since it's a global variable, not
   // constant and pocketlang doesn't support constant) so the user shouldn't
@@ -1219,19 +1177,20 @@ void initializeCore(PKVM* vm) {
   moduleAddGlobalInternal(vm, math, "PI", VAR_NUM(M_PI));
 
   Script* fiber = newModuleInternal(vm, "Fiber");
-  MODULE_ADD_FN(fiber, "new",      stdFiberNew,     1);
-  MODULE_ADD_FN(fiber, "run",      stdFiberRun,    -1);
-  MODULE_ADD_FN(fiber, "resume",   stdFiberResume, -1);
-
+  MODULE_ADD_FN(fiber, "new", stdFiberNew, 1);
+  MODULE_ADD_FN(fiber, "run", stdFiberRun, -1);
+  MODULE_ADD_FN(fiber, "resume", stdFiberResume, -1);
 }
 
 /*****************************************************************************/
 /* OPERATORS                                                                 */
 /*****************************************************************************/
 
-#define UNSUPPORTED_OPERAND_TYPES(op)                                  \
-  VM_SET_ERROR(vm, stringFormat(vm, "Unsupported operand types for "   \
-    "operator '" op "' $ and $", varTypeName(v1), varTypeName(v2)))
+#define UNSUPPORTED_OPERAND_TYPES(op)                            \
+  VM_SET_ERROR(vm, stringFormat(vm,                              \
+                                "Unsupported operand types for " \
+                                "operator '" op "' $ and $",     \
+                                varTypeName(v1), varTypeName(v2)))
 
 #define RIGHT_OPERAND "Right operand"
 
@@ -1248,16 +1207,13 @@ Var varAdd(PKVM* vm, Var v1, Var v2) {
   if (IS_OBJ(v1) && IS_OBJ(v2)) {
     Object *o1 = AS_OBJ(v1), *o2 = AS_OBJ(v2);
     switch (o1->type) {
-
-      case OBJ_STRING:
-      {
+      case OBJ_STRING: {
         if (o2->type == OBJ_STRING) {
           return VAR_OBJ(stringJoin(vm, (String*)o1, (String*)o2));
         }
       } break;
 
-      case OBJ_LIST:
-      {
+      case OBJ_LIST: {
         if (o2->type == OBJ_LIST) {
           return VAR_OBJ(listJoin(vm, (List*)o1, (List*)o2));
         }
@@ -1331,8 +1287,8 @@ Var varModulo(PKVM* vm, Var v1, Var v2) {
   }
 
   if (IS_OBJ_TYPE(v1, OBJ_STRING)) {
-    //const String* str = (const String*)AS_OBJ(v1);
-    TODO; // "fmt" % v2.
+    // const String* str = (const String*)AS_OBJ(v1);
+    TODO;  // "fmt" % v2.
   }
 
   UNSUPPORTED_OPERAND_TYPES("%");
@@ -1442,8 +1398,8 @@ bool varLesser(Var v1, Var v2) {
 
 bool varContains(PKVM* vm, Var elem, Var container) {
   if (!IS_OBJ(container)) {
-    VM_SET_ERROR(vm, stringFormat(vm, "'$' is not iterable.",
-                 varTypeName(container)));
+    VM_SET_ERROR(
+        vm, stringFormat(vm, "'$' is not iterable.", varTypeName(container)));
   }
   Object* obj = AS_OBJ(container);
 
@@ -1497,20 +1453,17 @@ bool varContains(PKVM* vm, Var elem, Var container) {
                                 varTypeName(on), attrib->data))
 
 Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
-
   if (!IS_OBJ(on)) {
-    VM_SET_ERROR(vm, stringFormat(vm, "$ type is not subscriptable.",
-                                  varTypeName(on)));
+    VM_SET_ERROR(
+        vm, stringFormat(vm, "$ type is not subscriptable.", varTypeName(on)));
     return VAR_NULL;
   }
 
   Object* obj = AS_OBJ(on);
   switch (obj->type) {
-    case OBJ_STRING:
-    {
+    case OBJ_STRING: {
       String* str = (String*)obj;
       switch (attrib->hash) {
-
         case CHECK_HASH("length", 0x83d03615):
           return VAR_NUM((double)(str->length));
 
@@ -1531,11 +1484,9 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       UNREACHABLE();
     }
 
-    case OBJ_LIST:
-    {
+    case OBJ_LIST: {
       List* list = (List*)obj;
       switch (attrib->hash) {
-
         case CHECK_HASH("length", 0x83d03615):
           return VAR_NUM((double)(list->elements.count));
 
@@ -1547,8 +1498,7 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       UNREACHABLE();
     }
 
-    case OBJ_MAP:
-    {
+    case OBJ_MAP: {
       // Not sure should I allow string values could be accessed with
       // this way. ex:
       // map = { "foo" : 42, "can't access" : 32 }
@@ -1557,17 +1507,16 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       UNREACHABLE();
     }
 
-    case OBJ_RANGE:
-    {
+    case OBJ_RANGE: {
       Range* range = (Range*)obj;
       switch (attrib->hash) {
-
         case CHECK_HASH("as_list", 0x1562c22):
           return VAR_OBJ(rangeAsList(vm, range));
 
-        // We can't use 'start', 'end' since 'end' in pocketlang is a
-        // keyword. Also we can't use 'from', 'to' since 'from' is a keyword
-        // too. So, we're using 'first' and 'last' to access the range limits.
+          // We can't use 'start', 'end' since 'end' in pocketlang is a
+          // keyword. Also we can't use 'from', 'to' since 'from' is a keyword
+          // too. So, we're using 'first' and 'last' to access the range
+          // limits.
 
         case CHECK_HASH("first", 0x4881d841):
           return VAR_NUM(range->from);
@@ -1583,8 +1532,7 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       UNREACHABLE();
     }
 
-    case OBJ_SCRIPT:
-    {
+    case OBJ_SCRIPT: {
       Script* scr = (Script*)obj;
 
       // Search in types.
@@ -1612,11 +1560,9 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       return VAR_NULL;
     }
 
-    case OBJ_FUNC:
-    {
+    case OBJ_FUNC: {
       Function* fn = (Function*)obj;
       switch (attrib->hash) {
-
         case CHECK_HASH("arity", 0x3e96bd7a):
           return VAR_NUM((double)(fn->arity));
 
@@ -1630,30 +1576,27 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
       UNREACHABLE();
     }
 
-    case OBJ_FIBER:
-      {
-        Fiber* fb = (Fiber*)obj;
-        switch (attrib->hash) {
+    case OBJ_FIBER: {
+      Fiber* fb = (Fiber*)obj;
+      switch (attrib->hash) {
+        case CHECK_HASH("is_done", 0x789c2706):
+          return VAR_BOOL(fb->state == FIBER_DONE);
 
-          case CHECK_HASH("is_done", 0x789c2706):
-            return VAR_BOOL(fb->state == FIBER_DONE);
+        case CHECK_HASH("function", 0x9ed64249):
+          return VAR_OBJ(fb->func);
 
-          case CHECK_HASH("function", 0x9ed64249):
-            return VAR_OBJ(fb->func);
-
-          default:
-            ERR_NO_ATTRIB(vm, on, attrib);
-            return VAR_NULL;
-          }
-        UNREACHABLE();
+        default:
+          ERR_NO_ATTRIB(vm, on, attrib);
+          return VAR_NULL;
       }
+      UNREACHABLE();
+    }
 
     case OBJ_CLASS:
       TODO;
       UNREACHABLE();
 
-    case OBJ_INST:
-    {
+    case OBJ_INST: {
       Var value;
       if (!instGetAttrib(vm, (Instance*)obj, attrib, &value)) {
         ERR_NO_ATTRIB(vm, on, attrib);
@@ -1670,18 +1613,19 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
 }
 
 void varSetAttrib(PKVM* vm, Var on, String* attrib, Var value) {
-
-#define ATTRIB_IMMUTABLE(name)                                                \
-do {                                                                          \
-  if ((attrib->length == strlen(name) && strcmp(name, attrib->data) == 0)) {  \
-    VM_SET_ERROR(vm, stringFormat(vm, "'$' attribute is immutable.", name));  \
-    return;                                                                   \
-  }                                                                           \
-} while (false)
+#define ATTRIB_IMMUTABLE(name)                                             \
+  do {                                                                     \
+    if ((attrib->length == strlen(name) &&                                 \
+         strcmp(name, attrib->data) == 0)) {                               \
+      VM_SET_ERROR(vm,                                                     \
+                   stringFormat(vm, "'$' attribute is immutable.", name)); \
+      return;                                                              \
+    }                                                                      \
+  } while (false)
 
   if (!IS_OBJ(on)) {
-    VM_SET_ERROR(vm, stringFormat(vm, "$ type is not subscriptable.",
-                                  varTypeName(on)));
+    VM_SET_ERROR(
+        vm, stringFormat(vm, "$ type is not subscriptable.", varTypeName(on)));
     return;
   }
 
@@ -1763,8 +1707,7 @@ do {                                                                          \
       ERR_NO_ATTRIB(vm, on, attrib);
       return;
 
-    case OBJ_INST:
-    {
+    case OBJ_INST: {
       if (!instSetAttrib(vm, (Instance*)obj, attrib, value)) {
         // If we has error by now, that means the set value type is
         // incompatible. No need for us to set an other error, just return.
@@ -1789,15 +1732,14 @@ do {                                                                          \
 
 Var varGetSubscript(PKVM* vm, Var on, Var key) {
   if (!IS_OBJ(on)) {
-    VM_SET_ERROR(vm, stringFormat(vm, "$ type is not subscriptable.",
-                                  varTypeName(on)));
+    VM_SET_ERROR(
+        vm, stringFormat(vm, "$ type is not subscriptable.", varTypeName(on)));
     return VAR_NULL;
   }
 
   Object* obj = AS_OBJ(on);
   switch (obj->type) {
-    case OBJ_STRING:
-    {
+    case OBJ_STRING: {
       int64_t index;
       String* str = ((String*)obj);
       if (!validateInteger(vm, key, &index, "List index")) {
@@ -1810,8 +1752,7 @@ Var varGetSubscript(PKVM* vm, Var on, Var key) {
       return VAR_OBJ(c);
     }
 
-    case OBJ_LIST:
-    {
+    case OBJ_LIST: {
       int64_t index;
       pkVarBuffer* elems = &((List*)obj)->elements;
       if (!validateInteger(vm, key, &index, "List index")) {
@@ -1823,11 +1764,9 @@ Var varGetSubscript(PKVM* vm, Var on, Var key) {
       return elems->data[index];
     }
 
-    case OBJ_MAP:
-    {
+    case OBJ_MAP: {
       Var value = mapGet((Map*)obj, key);
       if (IS_UNDEF(value)) {
-
         String* key_str = toString(vm, key);
         vmPushTempRef(vm, &key_str->_super);
         if (IS_OBJ(key) && !isObjectHashable(AS_OBJ(key)->type)) {
@@ -1859,8 +1798,8 @@ Var varGetSubscript(PKVM* vm, Var on, Var key) {
 
 void varsetSubscript(PKVM* vm, Var on, Var key, Var value) {
   if (!IS_OBJ(on)) {
-    VM_SET_ERROR(vm, stringFormat(vm, "$ type is not subscriptable.",
-                                  varTypeName(on)));
+    VM_SET_ERROR(
+        vm, stringFormat(vm, "$ type is not subscriptable.", varTypeName(on)));
     return;
   }
 
@@ -1870,8 +1809,7 @@ void varsetSubscript(PKVM* vm, Var on, Var key, Var value) {
       VM_SET_ERROR(vm, newString(vm, "String objects are immutable."));
       return;
 
-    case OBJ_LIST:
-    {
+    case OBJ_LIST: {
       int64_t index;
       pkVarBuffer* elems = &((List*)obj)->elements;
       if (!validateInteger(vm, key, &index, "List index")) return;
@@ -1880,11 +1818,10 @@ void varsetSubscript(PKVM* vm, Var on, Var key, Var value) {
       return;
     }
 
-    case OBJ_MAP:
-    {
+    case OBJ_MAP: {
       if (IS_OBJ(key) && !isObjectHashable(AS_OBJ(key)->type)) {
-        VM_SET_ERROR(vm, stringFormat(vm, "$ type is not hashable.",
-                                      varTypeName(key)));
+        VM_SET_ERROR(
+            vm, stringFormat(vm, "$ type is not hashable.", varTypeName(key)));
       } else {
         mapSet(vm, (Map*)obj, key, value);
       }

--- a/src/pk_core.h
+++ b/src/pk_core.h
@@ -30,21 +30,21 @@ Script* getCoreLib(const PKVM* vm, String* name);
 /* OPERATORS                                                                 */
 /*****************************************************************************/
 
-Var varAdd(PKVM* vm, Var v1, Var v2);         // Returns v1 + v2.
-Var varSubtract(PKVM* vm, Var v1, Var v2);    // Returns v1 - v2.
-Var varMultiply(PKVM* vm, Var v1, Var v2);    // Returns v1 * v2.
-Var varDivide(PKVM* vm, Var v1, Var v2);      // Returns v1 / v2.
-Var varModulo(PKVM* vm, Var v1, Var v2);      // Returns v1 % v2.
+Var varAdd(PKVM* vm, Var v1, Var v2);       // Returns v1 + v2.
+Var varSubtract(PKVM* vm, Var v1, Var v2);  // Returns v1 - v2.
+Var varMultiply(PKVM* vm, Var v1, Var v2);  // Returns v1 * v2.
+Var varDivide(PKVM* vm, Var v1, Var v2);    // Returns v1 / v2.
+Var varModulo(PKVM* vm, Var v1, Var v2);    // Returns v1 % v2.
 
-Var varBitAnd(PKVM* vm, Var v1, Var v2);      // Returns v1 & v2.
-Var varBitOr(PKVM* vm, Var v1, Var v2);       // Returns v1 | v2.
-Var varBitXor(PKVM* vm, Var v1, Var v2);      // Returns v1 ^ v2.
-Var varBitLshift(PKVM* vm, Var v1, Var v2);   // Returns v1 << v2.
-Var varBitRshift(PKVM* vm, Var v1, Var v2);   // Returns v1 >> v2.
-Var varBitNot(PKVM* vm, Var v);               // Returns ~v.
+Var varBitAnd(PKVM* vm, Var v1, Var v2);     // Returns v1 & v2.
+Var varBitOr(PKVM* vm, Var v1, Var v2);      // Returns v1 | v2.
+Var varBitXor(PKVM* vm, Var v1, Var v2);     // Returns v1 ^ v2.
+Var varBitLshift(PKVM* vm, Var v1, Var v2);  // Returns v1 << v2.
+Var varBitRshift(PKVM* vm, Var v1, Var v2);  // Returns v1 >> v2.
+Var varBitNot(PKVM* vm, Var v);              // Returns ~v.
 
-bool varGreater(Var v1, Var v2); // Returns v1 > v2.
-bool varLesser(Var v1, Var v2);  // Returns v1 < v2.
+bool varGreater(Var v1, Var v2);  // Returns v1 > v2.
+bool varLesser(Var v1, Var v2);   // Returns v1 < v2.
 
 // Returns elem in container.
 bool varContains(PKVM* vm, Var elem, Var container);
@@ -62,4 +62,4 @@ Var varGetSubscript(PKVM* vm, Var on, Var key);
 // Set subscript [value] with the [key] (ie. on[key] = value).
 void varsetSubscript(PKVM* vm, Var on, Var key, Var value);
 
-#endif // CORE_H
+#endif  // CORE_H

--- a/src/pk_debug.h
+++ b/src/pk_debug.h
@@ -23,4 +23,4 @@ void dumpGlobalValues(PKVM* vm);
 // Dump the current (top most) stack call frame.
 void dumpStackFrame(PKVM* vm);
 
-#endif // DEBUG_H
+#endif  // DEBUG_H

--- a/src/pk_internal.h
+++ b/src/pk_internal.h
@@ -7,7 +7,6 @@
 #define PK_INTERNAL
 
 #include "include/pocketlang.h"
-
 #include "pk_common.h"
 
 // Commonly used c standard headers across the sources. Don't include any
@@ -62,21 +61,19 @@
 /*****************************************************************************/
 
 // Allocate object of [type] using the vmRealloc function.
-#define ALLOCATE(vm, type) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type)))
+#define ALLOCATE(vm, type) ((type*)vmRealloc(vm, NULL, 0, sizeof(type)))
 
 // Allocate object of [type] which has a dynamic tail array of type [tail_type]
 // with [count] entries.
 #define ALLOCATE_DYNAMIC(vm, type, count, tail_type) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type) + sizeof(tail_type) * (count)))
+  ((type*)vmRealloc(vm, NULL, 0, sizeof(type) + sizeof(tail_type) * (count)))
 
 // Allocate [count] amount of object of [type] array.
 #define ALLOCATE_ARRAY(vm, type, count) \
-    ((type*)vmRealloc(vm, NULL, 0, sizeof(type) * (count)))
+  ((type*)vmRealloc(vm, NULL, 0, sizeof(type) * (count)))
 
 // Deallocate a pointer allocated by vmRealloc before.
-#define DEALLOCATE(vm, pointer) \
-    vmRealloc(vm, pointer, 0, 0)
+#define DEALLOCATE(vm, pointer) vmRealloc(vm, pointer, 0, 0)
 
 /*****************************************************************************/
 /* REUSABLE INTERNAL MACROS                                                  */
@@ -102,4 +99,4 @@
 //
 #define CHECK_HASH(name, hash) hash
 
-#endif // PK_INTERNAL
+#endif  // PK_INTERNAL

--- a/src/pk_opcodes.h
+++ b/src/pk_opcodes.h
@@ -118,7 +118,7 @@ OPCODE(IMPORT, 2, 1)
 // done the stack top should be stored otherwise it'll be disregarded. The
 // function should set the 0 th argment to return value.
 // params: 1 byte argc.
-OPCODE(CALL, 1, -0) //< Stack size will calculated at compile time.
+OPCODE(CALL, 1, -0)  //< Stack size will calculated at compile time.
 
 // Moves the [n] arguments and the function at the stack top to the current
 // frame's base for the tail call (the caller's frame it taken by the callee)
@@ -130,7 +130,7 @@ OPCODE(CALL, 1, -0) //< Stack size will calculated at compile time.
 // place once the function is called (rbp). So we're jumping from a deep nested
 // calls to the initial caller directly once the function is done.
 // params: 1 byte argc.
-OPCODE(TAIL_CALL, 1, -0) //< Stack size will calculated at compile time.
+OPCODE(TAIL_CALL, 1, -0)  //< Stack size will calculated at compile time.
 
 // Starts the iteration and test the sequence if it's iterable, before the
 // iteration instead of checking it everytime.
@@ -186,9 +186,9 @@ OPCODE(GET_SUBSCRIPT_KEEP, 0, 1)
 OPCODE(SET_SUBSCRIPT, 0, -2)
 
 // Pop unary operand and push value.
-OPCODE(NEGATIVE, 0, 0) //< Negative number value.
-OPCODE(NOT, 0, 0)      //< boolean not.
-OPCODE(BIT_NOT, 0, 0)  //< bitwise not.
+OPCODE(NEGATIVE, 0, 0)  //< Negative number value.
+OPCODE(NOT, 0, 0)       //< boolean not.
+OPCODE(BIT_NOT, 0, 0)   //< bitwise not.
 
 // Pop binary operands and push value.
 OPCODE(ADD, 0, -1)
@@ -210,7 +210,7 @@ OPCODE(LTEQ, 0, -1)
 OPCODE(GT, 0, -1)
 OPCODE(GTEQ, 0, -1)
 
-OPCODE(RANGE, 0, -1) //< Pop 2 integer make range push.
+OPCODE(RANGE, 0, -1)  //< Pop 2 integer make range push.
 OPCODE(IN, 0, -1)
 
 // Print the repr string of the value at the stack top, used in REPL mode.

--- a/src/pk_utils.c
+++ b/src/pk_utils.c
@@ -24,9 +24,7 @@ bool utilIsName(char c) {
 }
 
 // Function implementation, see utils.h for description.
-bool utilIsDigit(char c) {
-  return ('0' <= c && c <= '9');
-}
+bool utilIsDigit(char c) { return ('0' <= c && c <= '9'); }
 
 // A union to reinterpret a double as raw bits and back.
 typedef union {
@@ -93,7 +91,7 @@ uint32_t utilHashString(const char* string) {
  * UTF8                                                                     *
  ****************************************************************************/
 
- // Function implementation, see utils.h for description.
+// Function implementation, see utils.h for description.
 int utf8_encodeBytesCount(int value) {
   if (value <= 0x7f) return 1;
   if (value <= 0x7ff) return 2;
@@ -106,9 +104,8 @@ int utf8_encodeBytesCount(int value) {
 
 // Function implementation, see utils.h for description.
 int utf8_decodeBytesCount(uint8_t byte) {
-
   if ((byte >> 7) == 0b0) return 1;
-  if ((byte >> 6) == 0b10) return 1; //< continuation byte
+  if ((byte >> 6) == 0b10) return 1;  //< continuation byte
   if ((byte >> 5) == 0b110) return 2;
   if ((byte >> 4) == 0b1110) return 3;
   if ((byte >> 3) == 0b11110) return 4;
@@ -119,7 +116,6 @@ int utf8_decodeBytesCount(uint8_t byte) {
 
 // Function implementation, see utils.h for description.
 int utf8_encodeValue(int value, uint8_t* bytes) {
-
   if (value <= 0x7f) {
     *bytes = value & 0x7f;
     return 1;
@@ -138,7 +134,7 @@ int utf8_encodeValue(int value, uint8_t* bytes) {
   if (value <= 0xffff) {
     *(bytes++) = (uint8_t)(0b11100000 | ((value & 0b1111000000000000) >> 12));
     *(bytes++) = (uint8_t)(0b10000000 | ((value & 0b111111000000) >> 6));
-    *(bytes) =   (uint8_t)(0b10000000 | ((value & 0b111111)));
+    *(bytes) = (uint8_t)(0b10000000 | ((value & 0b111111)));
     return 3;
   }
 
@@ -146,10 +142,10 @@ int utf8_encodeValue(int value, uint8_t* bytes) {
   // to 4th byte, next 6 bits to 3rd byte, next 6 bits to 2nd byte, 3 bits
   // first byte.
   if (value <= 0x10ffff) {
-    *(bytes++) = (uint8_t)(0b11110000 | ((value & (0b111    << 18)) >> 18));
+    *(bytes++) = (uint8_t)(0b11110000 | ((value & (0b111 << 18)) >> 18));
     *(bytes++) = (uint8_t)(0b10000000 | ((value & (0b111111 << 12)) >> 12));
-    *(bytes++) = (uint8_t)(0b10000000 | ((value & (0b111111 << 6))  >> 6));
-    *(bytes)   = (uint8_t)(0b10000000 | ((value &  0b111111)));
+    *(bytes++) = (uint8_t)(0b10000000 | ((value & (0b111111 << 6)) >> 6));
+    *(bytes) = (uint8_t)(0b10000000 | ((value & 0b111111)));
     return 4;
   }
 
@@ -158,7 +154,6 @@ int utf8_encodeValue(int value, uint8_t* bytes) {
 
 // Function implementation, see utils.h for description.
 int utf8_decodeBytes(uint8_t* bytes, int* value) {
-
   int continue_bytes = 0;
   int byte_count = 1;
   int _value = 0;

--- a/src/pk_utils.h
+++ b/src/pk_utils.h
@@ -9,7 +9,8 @@
 #include "pk_internal.h"
 
 // Returns the smallest power of two that is equal to or greater than [n].
-// Source : https://github.com/wren-lang/wren/blob/main/src/vm/wren_utils.h#L119
+// Source :
+// https://github.com/wren-lang/wren/blob/main/src/vm/wren_utils.h#L119
 int utilPowerOf2Ceil(int n);
 
 // Returns true if `c` is [A-Za-z_].
@@ -33,7 +34,7 @@ uint32_t utilHashNumber(double num);
 // Generate a has code for [string].
 uint32_t utilHashString(const char* string);
 
-#endif // UTILS_H
+#endif  // UTILS_H
 
 /****************************************************************************
  * UTF8                                                                     *
@@ -79,7 +80,7 @@ uint32_t utilHashString(const char* string);
  *     // define implementation only a single *.c source file like this
  *     #define UTF8_IMPLEMENT
  *     #include "utf8.h"
-*/
+ */
 
 #include <stdint.h>
 
@@ -120,4 +121,4 @@ int utf8_encodeValue(int value, uint8_t* bytes);
 // value.
 int utf8_decodeBytes(uint8_t* bytes, int* value);
 
-#endif // UTF8_H
+#endif  // UTF8_H

--- a/src/pk_var.c
+++ b/src/pk_var.c
@@ -5,8 +5,8 @@
 
 #include "pk_var.h"
 
-#include <math.h>
 #include <ctype.h>
+#include <math.h>
 
 #include "pk_utils.h"
 #include "pk_vm.h"
@@ -27,15 +27,24 @@ PkVarType pkGetValueType(const PkVar value) {
 
   const Object* obj = AS_OBJ(*(const Var*)(value));
   switch (obj->type) {
-    case OBJ_STRING: return PK_STRING;
-    case OBJ_LIST:   return PK_LIST;
-    case OBJ_MAP:    return PK_MAP;
-    case OBJ_RANGE:  return PK_RANGE;
-    case OBJ_SCRIPT: return PK_SCRIPT;
-    case OBJ_FUNC:   return PK_FUNCTION;
-    case OBJ_FIBER:  return PK_FIBER;
-    case OBJ_CLASS:  return PK_CLASS;
-    case OBJ_INST:   return PK_INST;
+    case OBJ_STRING:
+      return PK_STRING;
+    case OBJ_LIST:
+      return PK_LIST;
+    case OBJ_MAP:
+      return PK_MAP;
+    case OBJ_RANGE:
+      return PK_RANGE;
+    case OBJ_SCRIPT:
+      return PK_SCRIPT;
+    case OBJ_FUNC:
+      return PK_FUNCTION;
+    case OBJ_FIBER:
+      return PK_FIBER;
+    case OBJ_CLASS:
+      return PK_CLASS;
+    case OBJ_INST:
+      return PK_INST;
   }
 
   UNREACHABLE();
@@ -43,33 +52,33 @@ PkVarType pkGetValueType(const PkVar value) {
 
 PkHandle* pkNewString(PKVM* vm, const char* value) {
   String* str = newString(vm, value);
-  vmPushTempRef(vm, &str->_super); // str
+  vmPushTempRef(vm, &str->_super);  // str
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(str));
-  vmPopTempRef(vm); // str
+  vmPopTempRef(vm);  // str
   return handle;
 }
 
 PkHandle* pkNewStringLength(PKVM* vm, const char* value, size_t len) {
   String* str = newStringLength(vm, value, (uint32_t)len);
-  vmPushTempRef(vm, &str->_super); // str
+  vmPushTempRef(vm, &str->_super);  // str
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(str));
-  vmPopTempRef(vm); // str
+  vmPopTempRef(vm);  // str
   return handle;
 }
 
 PkHandle* pkNewList(PKVM* vm) {
   List* list = newList(vm, MIN_CAPACITY);
-  vmPushTempRef(vm, &list->_super); // list
+  vmPushTempRef(vm, &list->_super);  // list
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(list));
-  vmPopTempRef(vm); // list
+  vmPopTempRef(vm);  // list
   return handle;
 }
 
 PkHandle* pkNewMap(PKVM* vm) {
   Map* map = newMap(vm);
-  vmPushTempRef(vm, &map->_super); // map
+  vmPushTempRef(vm, &map->_super);  // map
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(map));
-  vmPopTempRef(vm); // map
+  vmPopTempRef(vm);  // map
   return handle;
 }
 
@@ -77,17 +86,17 @@ PkHandle* pkNewFiber(PKVM* vm, PkHandle* fn) {
   __ASSERT(IS_OBJ_TYPE(fn->value, OBJ_FUNC), "Fn should be of type function.");
 
   Fiber* fiber = newFiber(vm, (Function*)AS_OBJ(fn->value));
-  vmPushTempRef(vm, &fiber->_super); // fiber
+  vmPushTempRef(vm, &fiber->_super);  // fiber
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(fiber));
-  vmPopTempRef(vm); // fiber
+  vmPopTempRef(vm);  // fiber
   return handle;
 }
 
 PkHandle* pkNewInstNative(PKVM* vm, void* data, uint32_t id) {
   Instance* inst = newInstanceNative(vm, data, id);
-  vmPushTempRef(vm, &inst->_super); // inst
+  vmPushTempRef(vm, &inst->_super);  // inst
   PkHandle* handle = vmNewHandle(vm, VAR_OBJ(inst));
-  vmPopTempRef(vm); // inst
+  vmPopTempRef(vm);  // inst
   return handle;
 }
 
@@ -137,9 +146,8 @@ void markObject(PKVM* vm, Object* self) {
   if (vm->working_set_count >= vm->working_set_capacity) {
     vm->working_set_capacity *= 2;
     vm->working_set = (Object**)vm->config.realloc_fn(
-                                    vm->working_set,
-                                    vm->working_set_capacity * sizeof(Object*),
-                                    vm->config.user_data);
+        vm->working_set, vm->working_set_capacity * sizeof(Object*),
+        vm->config.user_data);
   }
 
   vm->working_set[vm->working_set_count++] = self;
@@ -202,8 +210,7 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
       vm->bytes_allocated += sizeof(Range);
     } break;
 
-    case OBJ_SCRIPT:
-    {
+    case OBJ_SCRIPT: {
       Script* scr = (Script*)obj;
       vm->bytes_allocated += sizeof(Script);
 
@@ -231,8 +238,7 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
       markObject(vm, &scr->body->_super);
     } break;
 
-    case OBJ_FUNC:
-    {
+    case OBJ_FUNC: {
       Function* func = (Function*)obj;
       vm->bytes_allocated += sizeof(Function);
 
@@ -242,13 +248,12 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
         Fn* fn = func->fn;
         vm->bytes_allocated += sizeof(Fn);
 
-        vm->bytes_allocated += sizeof(uint8_t)* fn->opcodes.capacity;
+        vm->bytes_allocated += sizeof(uint8_t) * fn->opcodes.capacity;
         vm->bytes_allocated += sizeof(uint32_t) * fn->oplines.capacity;
       }
     } break;
 
-    case OBJ_FIBER:
-    {
+    case OBJ_FIBER: {
       Fiber* fiber = (Fiber*)obj;
       vm->bytes_allocated += sizeof(Fiber);
 
@@ -272,8 +277,7 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
 
     } break;
 
-    case OBJ_CLASS:
-    {
+    case OBJ_CLASS: {
       Class* type = (Class*)obj;
       vm->bytes_allocated += sizeof(Class);
       markObject(vm, &type->owner->_super);
@@ -281,8 +285,7 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
       vm->bytes_allocated += sizeof(uint32_t) * type->field_names.capacity;
     } break;
 
-    case OBJ_INST:
-    {
+    case OBJ_INST: {
       Instance* inst = (Instance*)obj;
       if (!inst->is_native) {
         Inst* ins = inst->ins;
@@ -304,8 +307,8 @@ Var doubleToVar(double value) {
 #if VAR_NAN_TAGGING
   return utilDoubleToBits(value);
 #else
-#error TODO:
-#endif // VAR_NAN_TAGGING
+  #error TODO:
+#endif  // VAR_NAN_TAGGING
 }
 
 double varToDouble(Var value) {
@@ -313,7 +316,7 @@ double varToDouble(Var value) {
   return utilDoubleFromBits(value);
 #else
   #error TODO:
-#endif // VAR_NAN_TAGGING
+#endif  // VAR_NAN_TAGGING
 }
 
 static String* _allocateString(PKVM* vm, size_t length) {
@@ -326,7 +329,6 @@ static String* _allocateString(PKVM* vm, size_t length) {
 }
 
 String* newStringLength(PKVM* vm, const char* text, uint32_t length) {
-
   ASSERT(length == 0 || text != NULL, "Unexpected NULL string.");
 
   String* string = _allocateString(vm, length);
@@ -402,7 +404,7 @@ Script* newScript(PKVM* vm, String* name, bool is_core) {
 
     // TODO: Add ARGV as a global.
 
-    vmPopTempRef(vm); // script.
+    vmPopTempRef(vm);  // script.
   }
 
   return script;
@@ -410,11 +412,10 @@ Script* newScript(PKVM* vm, String* name, bool is_core) {
 
 Function* newFunction(PKVM* vm, const char* name, int length, Script* owner,
                       bool is_native, const char* docstring) {
-
   Function* func = ALLOCATE(vm, Function);
   varInitObject(&func->_super, vm, OBJ_FUNC);
 
-  vmPushTempRef(vm, &func->_super); // func
+  vmPushTempRef(vm, &func->_super);  // func
 
   if (owner == NULL) {
     ASSERT(is_native, OOPS);
@@ -428,7 +429,7 @@ Function* newFunction(PKVM* vm, const char* name, int length, Script* owner,
 
     func->name = owner->names.data[name_index]->data;
     func->owner = owner;
-    func->arity = -2; // -1 means variadic args.
+    func->arity = -2;  // -1 means variadic args.
     func->is_native = is_native;
   }
 
@@ -446,7 +447,7 @@ Function* newFunction(PKVM* vm, const char* name, int length, Script* owner,
   // Both native and script (TODO:) functions support docstring.
   func->docstring = docstring;
 
-  vmPopTempRef(vm); // func
+  vmPopTempRef(vm);  // func
   return func;
 }
 
@@ -499,7 +500,7 @@ Class* newClass(PKVM* vm, Script* scr, const char* name, uint32_t length) {
   Class* type = ALLOCATE(vm, Class);
   varInitObject(&type->_super, vm, OBJ_CLASS);
 
-  vmPushTempRef(vm, &type->_super); // type.
+  vmPushTempRef(vm, &type->_super);  // type.
 
   pkClassBufferWrite(&scr->classes, vm, type);
   type->owner = scr;
@@ -509,26 +510,25 @@ Class* newClass(PKVM* vm, Script* scr, const char* name, uint32_t length) {
   // Can't use '$' in string format. (TODO)
   String* ty_name = scr->names.data[type->name];
   String* dollar = newStringLength(vm, "$", 1);
-  vmPushTempRef(vm, &dollar->_super); // dollar
+  vmPushTempRef(vm, &dollar->_super);  // dollar
   String* ctor_name = stringFormat(vm, "@(Ctor:@)", dollar, ty_name);
-  vmPopTempRef(vm); // dollar
+  vmPopTempRef(vm);  // dollar
 
   // Constructor.
-  vmPushTempRef(vm, &ctor_name->_super); // ctor_name
-  type->ctor = newFunction(vm, ctor_name->data, ctor_name->length,
-                           scr, false, NULL);
-  vmPopTempRef(vm); // ctor_name
+  vmPushTempRef(vm, &ctor_name->_super);  // ctor_name
+  type->ctor =
+      newFunction(vm, ctor_name->data, ctor_name->length, scr, false, NULL);
+  vmPopTempRef(vm);  // ctor_name
 
-  vmPopTempRef(vm); // type.
+  vmPopTempRef(vm);  // type.
   return type;
 }
 
 Instance* newInstance(PKVM* vm, Class* ty, bool initialize) {
-
   Instance* inst = ALLOCATE(vm, Instance);
   varInitObject(&inst->_super, vm, OBJ_INST);
 
-  vmPushTempRef(vm, &inst->_super); // inst.
+  vmPushTempRef(vm, &inst->_super);  // inst.
 
   ASSERT(ty->name < ty->owner->names.count, OOPS);
   inst->name = ty->owner->names.data[ty->name]->data;
@@ -543,7 +543,7 @@ Instance* newInstance(PKVM* vm, Class* ty, bool initialize) {
     pkVarBufferFill(&ins->fields, vm, VAR_NULL, ty->field_names.count);
   }
 
-  vmPopTempRef(vm); // inst.
+  vmPopTempRef(vm);  // inst.
 
   return inst;
 }
@@ -585,7 +585,6 @@ String* stringLower(PKVM* vm, String* self) {
   uint32_t index = 0;
   for (const char* c = self->data; *c != '\0'; c++, index++) {
     if (isupper(*c)) {
-
       // It contain upper case letters, allocate new lower case string .
       String* lower = newStringLength(vm, self->data, self->length);
 
@@ -624,7 +623,6 @@ String* stringUpper(PKVM* vm, String* self) {
 }
 
 String* stringStrip(PKVM* vm, String* self) {
-
   // Implementation:
   //
   // "     a string with leading and trailing white space    "
@@ -684,23 +682,20 @@ String* stringFormat(PKVM* vm, const char* fmt, ...) {
   char* buff = result->data;
   for (const char* c = fmt; *c != '\0'; c++) {
     switch (*c) {
-      case '$':
-      {
+      case '$': {
         const char* string = va_arg(arg_list, const char*);
         size_t length = strlen(string);
         memcpy(buff, string, length);
         buff += length;
       } break;
 
-      case '@':
-      {
+      case '@': {
         String* string = va_arg(arg_list, String*);
         memcpy(buff, string->data, string->length);
         buff += string->length;
       } break;
 
-      default:
-      {
+      default: {
         *buff++ = *c;
       } break;
     }
@@ -712,7 +707,6 @@ String* stringFormat(PKVM* vm, const char* fmt, ...) {
 }
 
 String* stringJoin(PKVM* vm, String* str1, String* str2) {
-
   // Optimize end case.
   if (str1->length == 0) return str2;
   if (str2->length == 0) return str1;
@@ -729,7 +723,6 @@ String* stringJoin(PKVM* vm, String* str1, String* str2) {
 }
 
 void listInsert(PKVM* vm, List* self, uint32_t index, Var value) {
-
   // Add an empty slot at the end of the buffer.
   if (IS_OBJ(value)) vmPushTempRef(vm, AS_OBJ(value));
   pkVarBufferWrite(&self->elements, vm, VAR_NULL);
@@ -755,9 +748,9 @@ Var listRemoveAt(PKVM* vm, List* self, uint32_t index) {
 
   // Shrink the size if it's too much excess.
   if (self->elements.capacity / GROW_FACTOR >= self->elements.count) {
-    self->elements.data = (Var*)vmRealloc(vm, self->elements.data,
-      sizeof(Var) * self->elements.capacity,
-      sizeof(Var) * self->elements.capacity / GROW_FACTOR);
+    self->elements.data = (Var*)vmRealloc(
+        vm, self->elements.data, sizeof(Var) * self->elements.capacity,
+        sizeof(Var) * self->elements.capacity / GROW_FACTOR);
     self->elements.capacity /= GROW_FACTOR;
   }
 
@@ -768,7 +761,6 @@ Var listRemoveAt(PKVM* vm, List* self, uint32_t index) {
 }
 
 List* listJoin(PKVM* vm, List* l1, List* l2) {
-
   // Optimize end case.
   if (l1->elements.count == 0) return l2;
   if (l2->elements.count == 0) return l1;
@@ -786,12 +778,10 @@ List* listJoin(PKVM* vm, List* l1, List* l2) {
 
 // Return a hash value for the object.
 static uint32_t _hashObject(Object* obj) {
-
   ASSERT(isObjectHashable(obj->type),
          "Check if it's hashable before calling this method.");
 
   switch (obj->type) {
-
     case OBJ_STRING:
       return ((String*)obj)->hash;
 
@@ -799,8 +789,7 @@ static uint32_t _hashObject(Object* obj) {
     case OBJ_MAP:
       goto L_unhashable;
 
-    case OBJ_RANGE:
-    {
+    case OBJ_RANGE: {
       Range* range = (Range*)obj;
       return utilHashNumber(range->from) ^ utilHashNumber(range->to);
     }
@@ -836,7 +825,6 @@ uint32_t varHashValue(Var v) {
 // point to the entry, return false otherwise and points [result] to where
 // the entry should be inserted.
 static bool _mapFindEntry(Map* self, Var key, MapEntry** result) {
-
   // An empty map won't contain the key.
   if (self->capacity == 0) return false;
 
@@ -857,7 +845,6 @@ static bool _mapFindEntry(Map* self, Var key, MapEntry** result) {
       ASSERT(IS_BOOL(entry->value), OOPS);
 
       if (IS_TRUE(entry->value)) {
-
         // We've found a tombstone, if we haven't found one [tombstone] should
         // be updated. We still need to keep search for if the key exists.
         if (tombstone == NULL) tombstone = entry;
@@ -891,7 +878,6 @@ static bool _mapFindEntry(Map* self, Var key, MapEntry** result) {
 // Add the key, value pair to the entries array of the map. Returns true if
 // the entry added for the first time and false for replaced value.
 static bool _mapInsertEntry(Map* self, Var key, Var value) {
-
   ASSERT(self->capacity != 0, "Should ensure the capacity before inserting.");
 
   MapEntry* result;
@@ -908,7 +894,6 @@ static bool _mapInsertEntry(Map* self, Var key, Var value) {
 
 // Resize the map's size to the given [capacity].
 static void _mapResize(PKVM* vm, Map* self, uint32_t capacity) {
-
   MapEntry* old_entries = self->entries;
   uint32_t old_capacity = self->capacity;
 
@@ -937,7 +922,6 @@ Var mapGet(Map* self, Var key) {
 }
 
 void mapSet(PKVM* vm, Map* self, Var key, Var value) {
-
   // If map is about to fill, resize it first.
   if (self->count + 1 > self->capacity * MAP_LOAD_PERCENT / 100) {
     uint32_t capacity = self->capacity * GROW_FACTOR;
@@ -946,7 +930,7 @@ void mapSet(PKVM* vm, Map* self, Var key, Var value) {
   }
 
   if (_mapInsertEntry(self, key, value)) {
-    self->count++; //< A new key added.
+    self->count++;  //< A new key added.
   }
 }
 
@@ -975,10 +959,9 @@ Var mapRemoveKey(PKVM* vm, Map* self, Var key) {
     // Clear the map if it's empty.
     mapClear(vm, self);
 
- } else if ((self->capacity > MIN_CAPACITY) &&
+  } else if ((self->capacity > MIN_CAPACITY) &&
              (self->capacity / (GROW_FACTOR * GROW_FACTOR)) >
-             ((self->count * 100) / MAP_LOAD_PERCENT)) {
-
+                 ((self->count * 100) / MAP_LOAD_PERCENT)) {
     // We grow the map when it's filled 75% (MAP_LOAD_PERCENT) by 2
     // (GROW_FACTOR) but we're not shrink the map when it's half filled (ie.
     // half of the capacity is 75%). Instead we wait till it'll become 1/4 is
@@ -996,9 +979,7 @@ Var mapRemoveKey(PKVM* vm, Map* self, Var key) {
   return value;
 }
 
-bool fiberHasError(Fiber* fiber) {
-  return fiber->error != NULL;
-}
+bool fiberHasError(Fiber* fiber) { return fiber->error != NULL; }
 
 void freeObject(PKVM* vm, Object* self) {
   // TODO: Debug trace memory here.
@@ -1054,8 +1035,7 @@ void freeObject(PKVM* vm, Object* self) {
       pkUintBufferClear(&type->field_names, vm);
     } break;
 
-    case OBJ_INST:
-    {
+    case OBJ_INST: {
       Instance* inst = (Instance*)self;
 
       if (inst->is_native) {
@@ -1078,8 +1058,7 @@ void freeObject(PKVM* vm, Object* self) {
 }
 
 uint32_t scriptAddName(Script* self, PKVM* vm, const char* name,
-  uint32_t length) {
-
+                       uint32_t length) {
   for (uint32_t i = 0; i < self->names.count; i++) {
     String* _name = self->names.data[i];
     if (_name->length == length && strncmp(_name->data, name, length) == 0) {
@@ -1132,10 +1111,8 @@ int scriptGetGlobals(Script* script, const char* name, uint32_t length) {
   return -1;
 }
 
-uint32_t scriptAddGlobal(PKVM* vm, Script* script,
-                    const char* name, uint32_t length,
-                    Var value) {
-
+uint32_t scriptAddGlobal(PKVM* vm, Script* script, const char* name,
+                         uint32_t length, Var value) {
   // If already exists update the value.
   int var_ind = scriptGetGlobals(script, name, length);
   if (var_ind != -1) {
@@ -1156,8 +1133,8 @@ void scriptAddMain(PKVM* vm, Script* script) {
   ASSERT(script->body == NULL, OOPS);
 
   const char* fn_name = PK_IMPLICIT_MAIN_NAME;
-  script->body = newFunction(vm, fn_name, (int)strlen(fn_name),
-                             script, false, NULL/*TODO*/);
+  script->body = newFunction(vm, fn_name, (int)strlen(fn_name), script, false,
+                             NULL /*TODO*/);
   script->body->arity = 0;
   script->initialized = false;
 }
@@ -1171,7 +1148,6 @@ bool instGetAttrib(PKVM* vm, Instance* inst, String* attrib, Var* value) {
   ASSERT(vm->fiber != NULL, OOPS);
 
   if (inst->is_native) {
-
     if (vm->config.inst_get_attrib_fn) {
       // Temproarly change the fiber's "return address" to points to the
       // below var 'val' so that the users can use 'pkReturn...()' function
@@ -1180,16 +1156,15 @@ bool instGetAttrib(PKVM* vm, Instance* inst, String* attrib, Var* value) {
       Var val = VAR_UNDEFINED;
 
       vm->fiber->ret = &val;
-      PkStringPtr attr = { attrib->data, NULL, NULL,
-                           attrib->length, attrib->hash };
+      PkStringPtr attr = {attrib->data, NULL, NULL, attrib->length,
+                          attrib->hash};
       vm->config.inst_get_attrib_fn(vm, inst->native, inst->native_id, attr);
       vm->fiber->ret = temp;
 
       if (IS_UNDEF(val)) {
-
         // FIXME: add a list of attribute overrides.
         if (IS_CSTR_EQ(attrib, "as_string", 9,
-          CHECK_HASH("as_string", 0xbdef4147))) {
+                       CHECK_HASH("as_string", 0xbdef4147))) {
           *value = VAR_OBJ(toRepr(vm, VAR_OBJ(inst)));
           return true;
         }
@@ -1210,7 +1185,6 @@ bool instGetAttrib(PKVM* vm, Instance* inst, String* attrib, Var* value) {
     return false;
 
   } else {
-
     // TODO: Optimize this with binary search.
     Class* ty = inst->ins->type;
     for (uint32_t i = 0; i < ty->field_names.count; i++) {
@@ -1231,9 +1205,7 @@ bool instGetAttrib(PKVM* vm, Instance* inst, String* attrib, Var* value) {
 }
 
 bool instSetAttrib(PKVM* vm, Instance* inst, String* attrib, Var value) {
-
   if (inst->is_native) {
-
     if (vm->config.inst_set_attrib_fn) {
       // Temproarly change the fiber's "return address" to points to the
       // below var 'ret' so that the users can use 'pkGetArg...()' function
@@ -1242,8 +1214,8 @@ bool instSetAttrib(PKVM* vm, Instance* inst, String* attrib, Var value) {
       Var attrib_ptr = value;
 
       vm->fiber->ret = &attrib_ptr;
-      PkStringPtr attr = { attrib->data, NULL, NULL,
-                           attrib->length, attrib->hash };
+      PkStringPtr attr = {attrib->data, NULL, NULL, attrib->length,
+                          attrib->hash};
       bool exists = vm->config.inst_set_attrib_fn(vm, inst->native,
                                                   inst->native_id, attr);
       vm->fiber->ret = temp;
@@ -1262,16 +1234,14 @@ bool instSetAttrib(PKVM* vm, Instance* inst, String* attrib, Var value) {
     return false;
 
   } else {
-
     // TODO: Optimize this with binary search.
     Class* ty = inst->ins->type;
     for (uint32_t i = 0; i < ty->field_names.count; i++) {
       ASSERT_INDEX(i, ty->field_names.count);
       ASSERT_INDEX(ty->field_names.data[i], ty->owner->names.count);
       String* f_name = ty->owner->names.data[ty->field_names.data[i]];
-      if (f_name->hash == attrib->hash &&
-        f_name->length == attrib->length &&
-        memcmp(f_name->data, attrib->data, attrib->length) == 0) {
+      if (f_name->hash == attrib->hash && f_name->length == attrib->length &&
+          memcmp(f_name->data, attrib->data, attrib->length) == 0) {
         inst->ins->fields.data[i] = value;
         return true;
       }
@@ -1290,18 +1260,30 @@ bool instSetAttrib(PKVM* vm, Instance* inst, String* attrib, Var value) {
 
 const char* getPkVarTypeName(PkVarType type) {
   switch (type) {
-    case PK_NULL:     return "Null";
-    case PK_BOOL:     return "Bool";
-    case PK_NUMBER:   return "Number";
-    case PK_STRING:   return "String";
-    case PK_LIST:     return "List";
-    case PK_MAP:      return "Map";
-    case PK_RANGE:    return "Range";
-    case PK_SCRIPT:   return "Script";
-    case PK_FUNCTION: return "Function";
-    case PK_FIBER:    return "Fiber";
-    case PK_CLASS:    return "Class";
-    case PK_INST:     return "Inst";
+    case PK_NULL:
+      return "Null";
+    case PK_BOOL:
+      return "Bool";
+    case PK_NUMBER:
+      return "Number";
+    case PK_STRING:
+      return "String";
+    case PK_LIST:
+      return "List";
+    case PK_MAP:
+      return "Map";
+    case PK_RANGE:
+      return "Range";
+    case PK_SCRIPT:
+      return "Script";
+    case PK_FUNCTION:
+      return "Function";
+    case PK_FIBER:
+      return "Fiber";
+    case PK_CLASS:
+      return "Class";
+    case PK_INST:
+      return "Inst";
   }
 
   UNREACHABLE();
@@ -1309,15 +1291,24 @@ const char* getPkVarTypeName(PkVarType type) {
 
 const char* getObjectTypeName(ObjectType type) {
   switch (type) {
-    case OBJ_STRING:  return "String";
-    case OBJ_LIST:    return "List";
-    case OBJ_MAP:     return "Map";
-    case OBJ_RANGE:   return "Range";
-    case OBJ_SCRIPT:  return "Script";
-    case OBJ_FUNC:    return "Func";
-    case OBJ_FIBER:   return "Fiber";
-    case OBJ_CLASS:   return "Class";
-    case OBJ_INST:    return "Inst";
+    case OBJ_STRING:
+      return "String";
+    case OBJ_LIST:
+      return "List";
+    case OBJ_MAP:
+      return "Map";
+    case OBJ_RANGE:
+      return "Range";
+    case OBJ_SCRIPT:
+      return "Script";
+    case OBJ_FUNC:
+      return "Func";
+    case OBJ_FIBER:
+      return "Fiber";
+    case OBJ_CLASS:
+      return "Class";
+    case OBJ_INST:
+      return "Inst";
   }
   UNREACHABLE();
 }
@@ -1325,7 +1316,7 @@ const char* getObjectTypeName(ObjectType type) {
 const char* varTypeName(Var v) {
   if (IS_NULL(v)) return "Null";
   if (IS_BOOL(v)) return "Bool";
-  if (IS_NUM(v))  return "Number";
+  if (IS_NUM(v)) return "Number";
 
   ASSERT(IS_OBJ(v), OOPS);
   Object* obj = AS_OBJ(v);
@@ -1347,28 +1338,27 @@ bool isValuesEqual(Var v1, Var v2) {
   // If we reach here only heap allocated objects could be compared.
   if (!IS_OBJ(v1) || !IS_OBJ(v2)) return false;
 
-  Object* o1 = AS_OBJ(v1), *o2 = AS_OBJ(v2);
+  Object *o1 = AS_OBJ(v1), *o2 = AS_OBJ(v2);
   if (o1->type != o2->type) return false;
 
   switch (o1->type) {
     case OBJ_RANGE:
       return ((Range*)o1)->from == ((Range*)o2)->from &&
-             ((Range*)o1)->to   == ((Range*)o2)->to;
+             ((Range*)o1)->to == ((Range*)o2)->to;
 
     case OBJ_STRING: {
-      String* s1 = (String*)o1, *s2 = (String*)o2;
-      return s1->hash == s2->hash &&
-             s1->length == s2->length &&
+      String *s1 = (String*)o1, *s2 = (String*)o2;
+      return s1->hash == s2->hash && s1->length == s2->length &&
              memcmp(s1->data, s2->data, s1->length) == 0;
     }
 
     case OBJ_LIST: {
       /*
-      * l1 = []; list_append(l1, l1) # [[...]]
-      * l2 = []; list_append(l2, l2) # [[...]]
-      * l1 == l2 ## This will cause a stack overflow but not handling that
-      *          ## (in python too).
-      */
+       * l1 = []; list_append(l1, l1) # [[...]]
+       * l2 = []; list_append(l2, l2) # [[...]]
+       * l1 == l2 ## This will cause a stack overflow but not handling that
+       *          ## (in python too).
+       */
       List *l1 = (List*)o1, *l2 = (List*)o2;
       if (l1->elements.count != l2->elements.count) return false;
       Var* _v1 = l1->elements.data;
@@ -1413,8 +1403,10 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
     return;
 
   } else if (IS_BOOL(v)) {
-    if (AS_BOOL(v)) pkByteBufferAddString(buff, vm, "true", 4);
-    else pkByteBufferAddString(buff, vm, "false", 5);
+    if (AS_BOOL(v))
+      pkByteBufferAddString(buff, vm, "true", 4);
+    else
+      pkByteBufferAddString(buff, vm, "false", 5);
     return;
 
   } else if (IS_NUM(v)) {
@@ -1439,12 +1431,9 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
     return;
 
   } else if (IS_OBJ(v)) {
-
     const Object* obj = AS_OBJ(v);
     switch (obj->type) {
-
-      case OBJ_STRING:
-      {
+      case OBJ_STRING: {
         const String* str = (const String*)obj;
         if (outer == NULL && !repr) {
           pkByteBufferAddString(buff, vm, str->data, str->length);
@@ -1454,11 +1443,21 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
           pkByteBufferWrite(buff, vm, '"');
           for (const char* c = str->data; *c != '\0'; c++) {
             switch (*c) {
-              case '"': pkByteBufferAddString(buff, vm, "\\\"", 2); break;
-              case '\\': pkByteBufferAddString(buff, vm, "\\\\", 2); break;
-              case '\n': pkByteBufferAddString(buff, vm, "\\n", 2); break;
-              case '\r': pkByteBufferAddString(buff, vm, "\\r", 2); break;
-              case '\t': pkByteBufferAddString(buff, vm, "\\t", 2); break;
+              case '"':
+                pkByteBufferAddString(buff, vm, "\\\"", 2);
+                break;
+              case '\\':
+                pkByteBufferAddString(buff, vm, "\\\\", 2);
+                break;
+              case '\n':
+                pkByteBufferAddString(buff, vm, "\\n", 2);
+                break;
+              case '\r':
+                pkByteBufferAddString(buff, vm, "\\r", 2);
+                break;
+              case '\t':
+                pkByteBufferAddString(buff, vm, "\\t", 2);
+                break;
 
               default:
                 pkByteBufferWrite(buff, vm, *c);
@@ -1471,8 +1470,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         UNREACHABLE();
       }
 
-      case OBJ_LIST:
-      {
+      case OBJ_LIST: {
         const List* list = (const List*)obj;
         if (list->elements.count == 0) {
           pkByteBufferAddString(buff, vm, "[]", 2);
@@ -1489,7 +1487,9 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
           seq = seq->outer;
         }
         OuterSequence seq_list;
-        seq_list.outer = outer; seq_list.is_list = true; seq_list.list = list;
+        seq_list.outer = outer;
+        seq_list.is_list = true;
+        seq_list.list = list;
 
         pkByteBufferWrite(buff, vm, '[');
         for (uint32_t i = 0; i < list->elements.count; i++) {
@@ -1500,8 +1500,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         return;
       }
 
-      case OBJ_MAP:
-      {
+      case OBJ_MAP: {
         const Map* map = (const Map*)obj;
         if (map->entries == NULL) {
           pkByteBufferAddString(buff, vm, "{}", 2);
@@ -1518,13 +1517,14 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
           seq = seq->outer;
         }
         OuterSequence seq_map;
-        seq_map.outer = outer; seq_map.is_list = false; seq_map.map = map;
+        seq_map.outer = outer;
+        seq_map.is_list = false;
+        seq_map.map = map;
 
         pkByteBufferWrite(buff, vm, '{');
-        uint32_t i = 0;     // Index of the current entry to iterate.
-        bool _first = true; // For first element no ',' required.
+        uint32_t i = 0;      // Index of the current entry to iterate.
+        bool _first = true;  // For first element no ',' required.
         do {
-
           // Get the next valid key index.
           bool _done = false;
           while (IS_UNDEF(map->entries[i].key)) {
@@ -1541,23 +1541,23 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
           pkByteBufferWrite(buff, vm, ':');
           _toStringInternal(vm, map->entries[i].value, buff, &seq_map, true);
 
-          i++; _first = false;
+          i++;
+          _first = false;
         } while (i < map->capacity);
 
         pkByteBufferWrite(buff, vm, '}');
         return;
       }
 
-      case OBJ_RANGE:
-      {
+      case OBJ_RANGE: {
         const Range* range = (const Range*)obj;
 
         char buff_from[STR_DBL_BUFF_SIZE];
-        const int len_from = snprintf(buff_from, sizeof(buff_from),
-                                      DOUBLE_FMT, range->from);
+        const int len_from =
+            snprintf(buff_from, sizeof(buff_from), DOUBLE_FMT, range->from);
         char buff_to[STR_DBL_BUFF_SIZE];
-        const int len_to = snprintf(buff_to, sizeof(buff_to),
-                                    DOUBLE_FMT, range->to);
+        const int len_to =
+            snprintf(buff_to, sizeof(buff_to), DOUBLE_FMT, range->to);
 
         pkByteBufferAddString(buff, vm, "[Range:", 7);
         pkByteBufferAddString(buff, vm, buff_from, len_from);
@@ -1572,7 +1572,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         pkByteBufferAddString(buff, vm, "[Module:", 8);
         if (scr->module != NULL) {
           pkByteBufferAddString(buff, vm, scr->module->data,
-                              scr->module->length);
+                                scr->module->length);
         } else {
           pkByteBufferWrite(buff, vm, '"');
           pkByteBufferAddString(buff, vm, scr->path->data, scr->path->length);
@@ -1594,7 +1594,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         const Fiber* fb = (const Fiber*)obj;
         pkByteBufferAddString(buff, vm, "[Fiber:", 7);
         pkByteBufferAddString(buff, vm, fb->func->name,
-                            (uint32_t)strlen(fb->func->name));
+                              (uint32_t)strlen(fb->func->name));
         pkByteBufferWrite(buff, vm, ']');
         return;
       }
@@ -1608,8 +1608,7 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         return;
       }
 
-      case OBJ_INST:
-      {
+      case OBJ_INST: {
         const Instance* inst = (const Instance*)obj;
         pkByteBufferWrite(buff, vm, '[');
         pkByteBufferAddString(buff, vm, inst->name,
@@ -1631,12 +1630,12 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
             _toStringInternal(vm, ins->fields.data[i], buff, outer, repr);
           }
         } else {
-
           char buff_addr[STR_HEX_BUFF_SIZE];
           char* ptr = (char*)buff_addr;
-          (*ptr++) = '0'; (*ptr++) = 'x';
-          const int len = snprintf(ptr, sizeof(buff_addr) - 2,
-                                "%08x", (unsigned int)(uintptr_t)inst->native);
+          (*ptr++) = '0';
+          (*ptr++) = 'x';
+          const int len = snprintf(ptr, sizeof(buff_addr) - 2, "%08x",
+                                   (unsigned int)(uintptr_t)inst->native);
           pkByteBufferAddString(buff, vm, buff_addr, (uint32_t)len);
         }
 
@@ -1644,14 +1643,12 @@ static void _toStringInternal(PKVM* vm, const Var v, pkByteBuffer* buff,
         return;
       }
     }
-
   }
   UNREACHABLE();
   return;
 }
 
 String* toString(PKVM* vm, const Var value) {
-
   // If it's already a string don't allocate a new string.
   if (IS_OBJ_TYPE(value, OBJ_STRING)) {
     return (String*)AS_OBJ(value);
@@ -1675,7 +1672,6 @@ String* toRepr(PKVM* vm, const Var value) {
 }
 
 bool toBool(Var v) {
-
   if (IS_BOOL(v)) return AS_BOOL(v);
   if (IS_NULL(v)) return false;
   if (IS_NUM(v)) return AS_NUM(v) != 0;
@@ -1683,10 +1679,13 @@ bool toBool(Var v) {
   ASSERT(IS_OBJ(v), OOPS);
   Object* o = AS_OBJ(v);
   switch (o->type) {
-    case OBJ_STRING: return ((String*)o)->length != 0;
-    case OBJ_LIST:   return ((List*)o)->elements.count != 0;
-    case OBJ_MAP:    return ((Map*)o)->count != 0;
-    case OBJ_RANGE: // [[FALLTHROUGH]]
+    case OBJ_STRING:
+      return ((String*)o)->length != 0;
+    case OBJ_LIST:
+      return ((List*)o)->elements.count != 0;
+    case OBJ_MAP:
+      return ((Map*)o)->count != 0;
+    case OBJ_RANGE:  // [[FALLTHROUGH]]
     case OBJ_SCRIPT:
     case OBJ_FUNC:
     case OBJ_FIBER:

--- a/src/pk_var.h
+++ b/src/pk_var.h
@@ -26,7 +26,7 @@
 // To use dynamic variably-sized struct with a tail array add an array at the
 // end of the struct with size DYNAMIC_TAIL_ARRAY. This method was a legacy
 // standard called "struct hack".
-#if defined(_MSC_VER) || __STDC_VERSION__ >= 199901L // std >= c99
+#if defined(_MSC_VER) || __STDC_VERSION__ >= 199901L  // std >= c99
   #define DYNAMIC_TAIL_ARRAY
 #else
   #define DYNAMIC_TAIL_ARRAY 0
@@ -38,9 +38,9 @@
 // There are 2 main implemenation of Var's internal representation. First one
 // is NaN-tagging, and the second one is union-tagging. (read below for more).
 #if VAR_NAN_TAGGING
-  typedef uint64_t Var;
+typedef uint64_t Var;
 #else
-  typedef struct Var Var;
+typedef struct Var Var;
 #endif
 
 /**
@@ -97,73 +97,73 @@
 
 #if VAR_NAN_TAGGING
 
-// Masks and payloads.
-#define _MASK_SIGN  ((uint64_t)0x8000000000000000)
-#define _MASK_QNAN  ((uint64_t)0x7ffc000000000000)
-#define _MASK_TYPE  ((uint64_t)0x0003000000000000)
-#define _MASK_CONST ((uint64_t)0x0004000000000000)
+  // Masks and payloads.
+  #define _MASK_SIGN ((uint64_t)0x8000000000000000)
+  #define _MASK_QNAN ((uint64_t)0x7ffc000000000000)
+  #define _MASK_TYPE ((uint64_t)0x0003000000000000)
+  #define _MASK_CONST ((uint64_t)0x0004000000000000)
 
-#define _MASK_INTEGER (_MASK_QNAN | (uint64_t)0x0002000000000000)
-#define _MASK_OBJECT  (_MASK_QNAN | (uint64_t)0x8000000000000000)
+  #define _MASK_INTEGER (_MASK_QNAN | (uint64_t)0x0002000000000000)
+  #define _MASK_OBJECT (_MASK_QNAN | (uint64_t)0x8000000000000000)
 
-#define _PAYLOAD_INTEGER ((uint64_t)0x00000000ffffffff)
-#define _PAYLOAD_OBJECT  ((uint64_t)0x0000ffffffffffff)
+  #define _PAYLOAD_INTEGER ((uint64_t)0x00000000ffffffff)
+  #define _PAYLOAD_OBJECT ((uint64_t)0x0000ffffffffffff)
 
-// Primitive types.
-#define VAR_NULL      (_MASK_QNAN | (uint64_t)0x0000000000000000)
-#define VAR_UNDEFINED (_MASK_QNAN | (uint64_t)0x0001000000000000)
-#define VAR_VOID      (_MASK_QNAN | (uint64_t)0x0001000000000001)
-#define VAR_FALSE     (_MASK_QNAN | (uint64_t)0x0001000000000002)
-#define VAR_TRUE      (_MASK_QNAN | (uint64_t)0x0001000000000003)
+  // Primitive types.
+  #define VAR_NULL (_MASK_QNAN | (uint64_t)0x0000000000000000)
+  #define VAR_UNDEFINED (_MASK_QNAN | (uint64_t)0x0001000000000000)
+  #define VAR_VOID (_MASK_QNAN | (uint64_t)0x0001000000000001)
+  #define VAR_FALSE (_MASK_QNAN | (uint64_t)0x0001000000000002)
+  #define VAR_TRUE (_MASK_QNAN | (uint64_t)0x0001000000000003)
 
-// Encode types.
-#define VAR_BOOL(value) ((value)? VAR_TRUE : VAR_FALSE)
-#define VAR_INT(value)  (_MASK_INTEGER | (uint32_t)(int32_t)(value))
-#define VAR_NUM(value)  (doubleToVar(value))
-#define VAR_OBJ(value) /* [value] is an instance of Object */ \
-  ((Var)(_MASK_OBJECT | (uint64_t)(uintptr_t)(&value->_super)))
+  // Encode types.
+  #define VAR_BOOL(value) ((value) ? VAR_TRUE : VAR_FALSE)
+  #define VAR_INT(value) (_MASK_INTEGER | (uint32_t)(int32_t)(value))
+  #define VAR_NUM(value) (doubleToVar(value))
+  #define VAR_OBJ(value) /* [value] is an instance of Object */ \
+    ((Var)(_MASK_OBJECT | (uint64_t)(uintptr_t)(&value->_super)))
 
-// Const casting.
-#define ADD_CONST(value)    ((value) | _MASK_CONST)
-#define REMOVE_CONST(value) ((value) & ~_MASK_CONST)
+  // Const casting.
+  #define ADD_CONST(value) ((value) | _MASK_CONST)
+  #define REMOVE_CONST(value) ((value) & ~_MASK_CONST)
 
-// Check types.
-#define IS_CONST(value) ((value & _MASK_CONST) == _MASK_CONST)
-#define IS_NULL(value)  ((value) == VAR_NULL)
-#define IS_UNDEF(value) ((value) == VAR_UNDEFINED)
-#define IS_FALSE(value) ((value) == VAR_FALSE)
-#define IS_TRUE(value)  ((value) == VAR_TRUE)
-#define IS_BOOL(value)  (IS_TRUE(value) || IS_FALSE(value))
-#define IS_INT(value)   ((value & _MASK_INTEGER) == _MASK_INTEGER)
-#define IS_NUM(value)   ((value & _MASK_QNAN) != _MASK_QNAN)
-#define IS_OBJ(value)   ((value & _MASK_OBJECT) == _MASK_OBJECT)
+  // Check types.
+  #define IS_CONST(value) ((value & _MASK_CONST) == _MASK_CONST)
+  #define IS_NULL(value) ((value) == VAR_NULL)
+  #define IS_UNDEF(value) ((value) == VAR_UNDEFINED)
+  #define IS_FALSE(value) ((value) == VAR_FALSE)
+  #define IS_TRUE(value) ((value) == VAR_TRUE)
+  #define IS_BOOL(value) (IS_TRUE(value) || IS_FALSE(value))
+  #define IS_INT(value) ((value & _MASK_INTEGER) == _MASK_INTEGER)
+  #define IS_NUM(value) ((value & _MASK_QNAN) != _MASK_QNAN)
+  #define IS_OBJ(value) ((value & _MASK_OBJECT) == _MASK_OBJECT)
 
-// Evaluate to true if the var is an object and type of [obj_type].
-#define IS_OBJ_TYPE(var, obj_type) IS_OBJ(var) && AS_OBJ(var)->type == obj_type
+  // Evaluate to true if the var is an object and type of [obj_type].
+  #define IS_OBJ_TYPE(var, obj_type) \
+    IS_OBJ(var) && AS_OBJ(var)->type == obj_type
 
-// Check if the 2 pocket strings are equal.
-#define IS_STR_EQ(s1, s2)          \
- (((s1)->hash == (s2)->hash) &&    \
- ((s1)->length == (s2)->length) && \
- (memcmp((const void*)(s1)->data, (const void*)(s2)->data, (s1)->length) == 0))
+  // Check if the 2 pocket strings are equal.
+  #define IS_STR_EQ(s1, s2)                                          \
+    (((s1)->hash == (s2)->hash) && ((s1)->length == (s2)->length) && \
+     (memcmp((const void*)(s1)->data, (const void*)(s2)->data,       \
+             (s1)->length) == 0))
 
-// Compare pocket string with c string.
-#define IS_CSTR_EQ(str, cstr, len, chash)  \
- (((str)->hash == chash) &&                \
- ((str)->length == len) &&                 \
- (memcmp((const void*)(str)->data, (const void*)(cstr), len) == 0))
+  // Compare pocket string with c string.
+  #define IS_CSTR_EQ(str, cstr, len, chash)              \
+    (((str)->hash == chash) && ((str)->length == len) && \
+     (memcmp((const void*)(str)->data, (const void*)(cstr), len) == 0))
 
-// Decode types.
-#define AS_BOOL(value) ((value) == VAR_TRUE)
-#define AS_INT(value)  ((int32_t)((value) & _PAYLOAD_INTEGER))
-#define AS_NUM(value)  (varToDouble(value))
-#define AS_OBJ(value)  ((Object*)(value & _PAYLOAD_OBJECT))
+  // Decode types.
+  #define AS_BOOL(value) ((value) == VAR_TRUE)
+  #define AS_INT(value) ((int32_t)((value)&_PAYLOAD_INTEGER))
+  #define AS_NUM(value) (varToDouble(value))
+  #define AS_OBJ(value) ((Object*)(value & _PAYLOAD_OBJECT))
 
-#define AS_STRING(value)  ((String*)AS_OBJ(value))
-#define AS_CSTRING(value) (AS_STRING(value)->data)
-#define AS_ARRAY(value)   ((List*)AS_OBJ(value))
-#define AS_MAP(value)     ((Map*)AS_OBJ(value))
-#define AS_RANGE(value)   ((Range*)AS_OBJ(value))
+  #define AS_STRING(value) ((String*)AS_OBJ(value))
+  #define AS_CSTRING(value) (AS_STRING(value)->data)
+  #define AS_ARRAY(value) ((List*)AS_OBJ(value))
+  #define AS_MAP(value) ((Map*)AS_OBJ(value))
+  #define AS_RANGE(value) ((Range*)AS_OBJ(value))
 
 #else
 
@@ -171,13 +171,13 @@
 //       starts with an underscore.
 
 typedef enum {
-  VAR_UNDEFINED, //< Internal type for exceptions.
-  VAR_NULL,      //< Null pointer type.
-  VAR_BOOL,      //< Yin and yang of software.
-  VAR_INT,       //< Only 32bit integers (for consistence with Nan-Tagging).
-  VAR_FLOAT,     //< Floats are stored as (64bit) double.
+  VAR_UNDEFINED,  //< Internal type for exceptions.
+  VAR_NULL,       //< Null pointer type.
+  VAR_BOOL,       //< Yin and yang of software.
+  VAR_INT,        //< Only 32bit integers (for consistence with Nan-Tagging).
+  VAR_FLOAT,      //< Floats are stored as (64bit) double.
 
-  VAR_OBJECT,    //< Base type for all \ref var_Object types.
+  VAR_OBJECT,  //< Base type for all \ref var_Object types.
 } VarType;
 
 struct Var {
@@ -190,7 +190,7 @@ struct Var {
   };
 };
 
-#endif // VAR_NAN_TAGGING
+#endif  // VAR_NAN_TAGGING
 
 // Type definition of pocketlang heap allocated types.
 typedef struct Object Object;
@@ -250,7 +250,7 @@ struct String {
 struct List {
   Object _super;
 
-  pkVarBuffer elements; //< Elements of the array.
+  pkVarBuffer elements;  //< Elements of the array.
 };
 
 typedef struct {
@@ -258,23 +258,23 @@ typedef struct {
   // the entry is new and available, if true it's a tombstone - the entry
   // previously used but then deleted.
 
-  Var key;   //< The entry's key or VAR_UNDEFINED of the entry is not in use.
-  Var value; //< The entry's value.
+  Var key;    //< The entry's key or VAR_UNDEFINED of the entry is not in use.
+  Var value;  //< The entry's value.
 } MapEntry;
 
 struct Map {
   Object _super;
 
-  uint32_t capacity; //< Allocated entry's count.
-  uint32_t count;    //< Number of entries in the map.
-  MapEntry* entries; //< Pointer to the contiguous array.
+  uint32_t capacity;  //< Allocated entry's count.
+  uint32_t count;     //< Number of entries in the map.
+  MapEntry* entries;  //< Pointer to the contiguous array.
 };
 
 struct Range {
   Object _super;
 
-  double from; //< Beggining of the range inclusive.
-  double to;   //< End of the range exclusive.
+  double from;  //< Beggining of the range inclusive.
+  double to;    //< End of the range exclusive.
 };
 
 struct Script {
@@ -282,19 +282,19 @@ struct Script {
 
   // For core libraries the module and the path are same and points to the
   // same String objects.
-  String* module; //< Module name of the script.
-  String* path;   //< Path of the script.
+  String* module;  //< Module name of the script.
+  String* path;    //< Path of the script.
 
-  pkVarBuffer globals;         //< Script level global variables.
-  pkUintBuffer global_names;   //< Name map to index in globals.
+  pkVarBuffer globals;        //< Script level global variables.
+  pkUintBuffer global_names;  //< Name map to index in globals.
 
   pkFunctionBuffer functions;  //< Functions of the script.
   pkClassBuffer classes;       //< Classes of the script.
 
-  pkStringBuffer names;        //< Name literals, attribute names, etc.
-  pkVarBuffer literals;        //< Script literal constant values.
+  pkStringBuffer names;  //< Name literals, attribute names, etc.
+  pkVarBuffer literals;  //< Script literal constant values.
 
-  Function* body;              //< Script body is an anonymous function.
+  Function* body;  //< Script body is an anonymous function.
 
   // When a script has globals, it's body need to be executed to initialize the
   // global values, this will be false if the module isn't initialized yet and
@@ -312,33 +312,33 @@ typedef struct {
 struct Function {
   Object _super;
 
-  const char* name; //< Name in the script [owner] or C literal.
-  Script* owner;    //< Owner script of the function.
-  int arity;        //< Number of argument the function expects.
+  const char* name;  //< Name in the script [owner] or C literal.
+  Script* owner;     //< Owner script of the function.
+  int arity;         //< Number of argument the function expects.
 
   // Docstring of the function, currently it's just the C string literal
   // pointer, refactor this into String* so that we can support public
   // native functions to provide a docstring.
   const char* docstring;
 
-  bool is_native;        //< True if Native function.
+  bool is_native;  //< True if Native function.
   union {
-    pkNativeFn native;   //< Native function pointer.
-    Fn* fn;              //< Script function pointer.
+    pkNativeFn native;  //< Native function pointer.
+    Fn* fn;             //< Script function pointer.
   };
 };
 
 typedef struct {
-  const uint8_t* ip;  //< Pointer to the next instruction byte code.
-  const Function* fn; //< Function of the frame.
-  Var* rbp;           //< Stack base pointer. (%rbp)
+  const uint8_t* ip;   //< Pointer to the next instruction byte code.
+  const Function* fn;  //< Function of the frame.
+  Var* rbp;            //< Stack base pointer. (%rbp)
 } CallFrame;
 
 typedef enum {
-  FIBER_NEW,     //< Fiber haven't started yet.
-  FIBER_RUNNING, //< Fiber is currently running.
-  FIBER_YIELDED, //< Yielded fiber, can be resumed.
-  FIBER_DONE,    //< Fiber finished and cannot be resumed.
+  FIBER_NEW,      //< Fiber haven't started yet.
+  FIBER_RUNNING,  //< Fiber is currently running.
+  FIBER_YIELDED,  //< Yielded fiber, can be resumed.
+  FIBER_DONE,     //< Fiber finished and cannot be resumed.
 } FiberState;
 
 struct Fiber {
@@ -353,7 +353,7 @@ struct Fiber {
   // The stack of the execution holding locals and temps. A heap will be
   // allocated and grow as needed.
   Var* stack;
-  int stack_size; //< Capacity of the allocated stack.
+  int stack_size;  //< Capacity of the allocated stack.
 
   // The stack pointer (%rsp) pointing to the stack top.
   Var* sp;
@@ -366,8 +366,8 @@ struct Fiber {
 
   // Heap allocated array of call frames will grow as needed.
   CallFrame* frames;
-  int frame_capacity; //< Capacity of the frames array.
-  int frame_count; //< Number of frame entry in frames.
+  int frame_capacity;  //< Capacity of the frames array.
+  int frame_count;     //< Number of frame entry in frames.
 
   // Caller of this fiber if it has one, NULL otherwise.
   Fiber* caller;
@@ -379,17 +379,17 @@ struct Fiber {
 struct Class {
   Object _super;
 
-  Script* owner; //< The script it belongs to.
-  uint32_t name; //< Index of the type's name in the script's name buffer.
+  Script* owner;  //< The script it belongs to.
+  uint32_t name;  //< Index of the type's name in the script's name buffer.
 
-  Function* ctor; //< The constructor function.
-  pkUintBuffer field_names; //< Buffer of field names.
+  Function* ctor;            //< The constructor function.
+  pkUintBuffer field_names;  //< Buffer of field names.
   // TODO: ordered names buffer for binary search.
 };
 
 typedef struct {
-  Class* type;        //< Class this instance belongs to.
-  pkVarBuffer fields; //< Var buffer of the instance.
+  Class* type;         //< Class this instance belongs to.
+  pkVarBuffer fields;  //< Var buffer of the instance.
 } Inst;
 
 struct Instance {
@@ -397,8 +397,8 @@ struct Instance {
 
   const char* name;  //< Name of the type it belongs to.
 
-  bool is_native;    //< True if it's a native type instance.
-  uint32_t native_id;   //< Unique ID of this native instance.
+  bool is_native;      //< True if it's a native type instance.
+  uint32_t native_id;  //< Unique ID of this native instance.
 
   union {
     void* native;  //< C struct pointer. // TODO:
@@ -420,13 +420,13 @@ String* newStringLength(PKVM* vm, const char* text, uint32_t length);
 // An inline function/macro implementation of newString(). Set below 0 to 1, to
 // make the implementation a static inline function, it's totally okey to
 // define a function inside a header as long as it's static (but not a fan).
-#if 0 // Function implementation.
+#if 0  // Function implementation.
   // Allocate new string using the cstring [text].
   static inline String* newString(PKVM* vm, const char* text) {
     uint32_t length = (text == NULL) ? 0 : (uint32_t)strlen(text);
     return newStringLength(vm, text, length);
   }
-#else // Macro implementation.
+#else  // Macro implementation.
   // Allocate new string using the cstring [text].
   #define newString(vm, text) \
     newStringLength(vm, text, (!text) ? 0 : (uint32_t)strlen(text))
@@ -533,11 +533,11 @@ String* stringJoin(PKVM* vm, String* str1, String* str2);
 // An inline function/macro implementation of listAppend(). Set below 0 to 1,
 // to make the implementation a static inline function, it's totally okey to
 // define a function inside a header as long as it's static (but not a fan).
-#if 0 // Function implementation.
+#if 0  // Function implementation.
   static inline void listAppend(PKVM* vm, List* self, Var value) {
     pkVarBufferWrite(&self->elements, vm, value);
   }
-#else // Macro implementation.
+#else  // Macro implementation.
   #define listAppend(vm, self, value) \
     pkVarBufferWrite(&self->elements, vm, value)
 #endif
@@ -588,9 +588,8 @@ int scriptGetFunc(Script* script, const char* name, uint32_t length);
 int scriptGetGlobals(Script* script, const char* name, uint32_t length);
 
 // Add a global [value] to the [scrpt] and return its index.
-uint32_t scriptAddGlobal(PKVM* vm, Script* script,
-                         const char* name, uint32_t length,
-                         Var value);
+uint32_t scriptAddGlobal(PKVM* vm, Script* script, const char* name,
+                         uint32_t length, Var value);
 
 // This will allocate a new implicit main function for the script and assign to
 // the script's body attribute. And the attribute initialized will be set to
@@ -647,9 +646,9 @@ String* toString(PKVM* vm, const Var value);
 
 // Returns the representation version of the [value], similar to python's
 // __repr__() method.
-String * toRepr(PKVM * vm, const Var value);
+String* toRepr(PKVM* vm, const Var value);
 
 // Returns the truthy value of the var.
 bool toBool(Var v);
 
-#endif // VAR_H
+#endif  // VAR_H

--- a/src/pk_vm.h
+++ b/src/pk_vm.h
@@ -49,9 +49,9 @@
 // they're member of function buffer of the script) and this struct is a single
 // entry of the array.
 typedef struct {
-  const char* name; //< Name of the function.
-  uint32_t length;  //< Length of the name.
-  Function* fn;     //< Native function pointer.
+  const char* name;  //< Name of the function.
+  uint32_t length;   //< Length of the name.
+  Function* fn;      //< Native function pointer.
 } BuiltinFn;
 
 // A doubly link list of vars that have reference in the host application.
@@ -66,7 +66,6 @@ struct PkHandle {
 // PocketLang Virtual Machine. It'll contain the state of the execution, stack,
 // heap, and manage memory allocations.
 struct PKVM {
-
   // The first object in the link list of all heap allocated objects.
   Object* first;
 
@@ -144,7 +143,8 @@ void* vmRealloc(PKVM* vm, void* memory, size_t old_size, size_t new_size);
 PkHandle* vmNewHandle(PKVM* vm, Var value);
 
 // Trigger garbage collection. This is an implementation of mark and sweep
-// garbage collection (https://en.wikipedia.org/wiki/Tracing_garbage_collection).
+// garbage collection
+// (https://en.wikipedia.org/wiki/Tracing_garbage_collection).
 //
 // 1. MARKING PHASE
 //
@@ -212,4 +212,4 @@ bool vmSwitchFiber(PKVM* vm, Fiber* fiber, Var* value);
 // yield value.
 void vmYieldFiber(PKVM* vm, Var* value);
 
-#endif // VM_H
+#endif  // VM_H

--- a/tests/native/example1.c
+++ b/tests/native/example1.c
@@ -10,24 +10,22 @@
 
 // The pocket script we're using to test.
 static const char* code =
-  "  from YourModule import variableToC \n"
-  "  a = 42                             \n"
-  "  b = variableToC(a)                 \n"
-  "  print('[pocket] b =', b)           \n"
-  ;
+    "  from YourModule import variableToC \n"
+    "  a = 42                             \n"
+    "  b = variableToC(a)                 \n"
+    "  print('[pocket] b =', b)           \n";
 
 /*****************************************************************************/
 /* MODULE FUNCTION                                                           */
 /*****************************************************************************/
 
 static void variableToC(PKVM* vm) {
-  
   // Get the parameter from pocket VM.
   double a;
   if (!pkGetArgNumber(vm, 1, &a)) return;
-  
+
   printf("[C] a = %f\n", a);
-  
+
   // Return value to the pocket VM.
   pkReturnNumber(vm, 3.14);
 }
@@ -37,8 +35,7 @@ static void variableToC(PKVM* vm) {
 /*****************************************************************************/
 
 // Error report callback.
-static void reportError(PKVM* vm, PkErrorType type,
-                        const char* file, int line,
+static void reportError(PKVM* vm, PkErrorType type, const char* file, int line,
                         const char* message) {
   fprintf(stderr, "Error: %s\n", message);
 }
@@ -53,30 +50,29 @@ static void stdoutWrite(PKVM* vm, const char* text) {
 /*****************************************************************************/
 
 int main(int argc, char** argv) {
-
   // Pocket VM configuration.
   PkConfiguration config = pkNewConfiguration();
-  config.error_fn  = reportError;
-  config.write_fn  = stdoutWrite;
-  //config.read_fn = stdinRead;
+  config.error_fn = reportError;
+  config.write_fn = stdoutWrite;
+  // config.read_fn = stdinRead;
 
   // Create a new pocket VM.
   PKVM* vm = pkNewVM(&config);
-  
+
   // Register your module.
   PkHandle* your_module = pkNewModule(vm, "YourModule");
-  pkModuleAddFunction(vm, your_module, "variableToC",  variableToC, 1);
+  pkModuleAddFunction(vm, your_module, "variableToC", variableToC, 1);
   pkReleaseHandle(vm, your_module);
-  
+
   // The path and the source code.
-  PkStringPtr source = { code, NULL, NULL, 0, 0 };
-  PkStringPtr path = { "./some/path/", NULL, NULL, 0, 0 };
-  
+  PkStringPtr source = {code, NULL, NULL, 0, 0};
+  PkStringPtr path = {"./some/path/", NULL, NULL, 0, 0};
+
   // Run the code.
-  PkResult result = pkInterpretSource(vm, source, path, NULL/*options*/);
-  
+  PkResult result = pkInterpretSource(vm, source, path, NULL /*options*/);
+
   // Free the VM.
   pkFreeVM(vm);
-  
+
   return (int)result;
 }

--- a/tests/native/example2.c
+++ b/tests/native/example2.c
@@ -6,41 +6,39 @@
 // This is an example on how to write your own custom type (Vector here) and
 // bind it with with the pocket VM.
 
+#include <math.h>
 #include <pocketlang.h>
-
 #include <stdio.h>
 #include <string.h>
-#include <math.h>
 
 // The script we're using to test the native Vector type.
 static const char* code =
-  "  import Vector # The native module.                  \n"
-  "  print('Module        =', Vector)                    \n"
-  "                                                      \n"
-  "  vec1 = Vector.new(1, 2) # Calling native method.    \n"
-  "  print('vec1          =', 'Vector.new(1, 2)')        \n"
-  "  print()                                             \n"
-  "                                                      \n"
-  "  # Using the native getter.                          \n"
-  "  print('vec1.x        =', vec1.x)                    \n"
-  "  print('vec1.y        =', vec1.y)                    \n"
-  "  print('vec1.length   =', vec1.length)               \n"
-  "  print()                                             \n"
-  "                                                      \n"
-  "  # Using the native setter.                          \n"
-  "  vec1.x = 3; vec1.y = 4;                             \n"
-  "  print('vec1.x        =', vec1.x)                    \n"
-  "  print('vec1.y        =', vec1.y)                    \n"
-  "  print('vec1.length   =', vec1.length)               \n"
-  "  print()                                             \n"
-  "                                                      \n"
-  "  vec2 = Vector.new(5, 6)                             \n"
-  "  vec3 = Vector.add(vec1, vec2)                       \n"
-  "  print('vec3          =', 'Vector.add(vec1, vec2)')  \n"
-  "  print('vec3.x        =', vec3.x)                    \n"
-  "  print('vec3.y        =', vec3.y)                    \n"
-  "                                                      \n"
-  ;
+    "  import Vector # The native module.                  \n"
+    "  print('Module        =', Vector)                    \n"
+    "                                                      \n"
+    "  vec1 = Vector.new(1, 2) # Calling native method.    \n"
+    "  print('vec1          =', 'Vector.new(1, 2)')        \n"
+    "  print()                                             \n"
+    "                                                      \n"
+    "  # Using the native getter.                          \n"
+    "  print('vec1.x        =', vec1.x)                    \n"
+    "  print('vec1.y        =', vec1.y)                    \n"
+    "  print('vec1.length   =', vec1.length)               \n"
+    "  print()                                             \n"
+    "                                                      \n"
+    "  # Using the native setter.                          \n"
+    "  vec1.x = 3; vec1.y = 4;                             \n"
+    "  print('vec1.x        =', vec1.x)                    \n"
+    "  print('vec1.y        =', vec1.y)                    \n"
+    "  print('vec1.length   =', vec1.length)               \n"
+    "  print()                                             \n"
+    "                                                      \n"
+    "  vec2 = Vector.new(5, 6)                             \n"
+    "  vec3 = Vector.add(vec1, vec2)                       \n"
+    "  print('vec3          =', 'Vector.add(vec1, vec2)')  \n"
+    "  print('vec3.x        =', vec3.x)                    \n"
+    "  print('vec3.y        =', vec3.y)                    \n"
+    "                                                      \n";
 
 /*****************************************************************************/
 /* NATIVE TYPE DEFINES & CALLBACKS                                           */
@@ -52,23 +50,23 @@ typedef enum {
 } ObjType;
 
 typedef struct {
-  double x, y; // Vector variables.
+  double x, y;  // Vector variables.
 } Vector;
 
 // Get name callback, will called from pocketlang to get the type name from
 // the ID (the enum value).
 const char* getObjName(uint32_t id) {
   switch ((ObjType)id) {
-    case OBJ_VECTOR: return "Vector";
+    case OBJ_VECTOR:
+      return "Vector";
   }
-  return NULL; // Unreachable.
+  return NULL;  // Unreachable.
 }
 
 // Instance getter callback to get a value from the native instance.
 // The hash value and the length of the string are provided with the
 // argument [attrib].
 void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
-  
   switch ((ObjType)id) {
     case OBJ_VECTOR: {
       Vector* vector = ((Vector*)instance);
@@ -76,7 +74,7 @@ void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
       if (strcmp(attrib.string, "x") == 0) {
         pkReturnNumber(vm, vector->x);
         return;
-        
+
       } else if (strcmp(attrib.string, "y") == 0) {
         pkReturnNumber(vm, vector->y);
         return;
@@ -85,11 +83,10 @@ void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
         double length = sqrt(pow(vector->x, 2) + pow(vector->y, 2));
         pkReturnNumber(vm, length);
         return;
-
       }
     } break;
   }
-  
+
   // If we reached here that means the attribute doesn't exists.
   // Since we haven't used pkReturn...() function, pocket VM already
   // know that the attribute doesn't exists. just return.
@@ -100,27 +97,25 @@ void objGetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
 // The hash value and the length of the string are provided with the
 // argument [attrib].
 bool objSetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
-  
   switch ((ObjType)id) {
     case OBJ_VECTOR: {
       Vector* vector = ((Vector*)instance);
 
       if (strcmp(attrib.string, "x") == 0) {
-        double x; // Get the number x.
+        double x;  // Get the number x.
         if (!pkGetArgNumber(vm, 0, &x)) return false;
         vector->x = x;
         return true;
-        
+
       } else if (strcmp(attrib.string, "y") == 0) {
-        double y; // Get the number x.
+        double y;  // Get the number x.
         if (!pkGetArgNumber(vm, 0, &y)) return false;
         vector->y = y;
         return true;
-        
       }
     } break;
   }
-  
+
   // If we reached here that means the attribute doesn't exists.
   // Return false to indicate it.
   return false;
@@ -129,7 +124,7 @@ bool objSetAttrib(PKVM* vm, void* instance, uint32_t id, PkStringPtr attrib) {
 // The free object callback, called just before the native instance, garbage
 // collect.
 void freeObj(PKVM* vm, void* instance, uint32_t id) {
-  free((void*)instance); // Your cleanups.
+  free((void*)instance);  // Your cleanups.
 }
 
 /*****************************************************************************/
@@ -138,12 +133,12 @@ void freeObj(PKVM* vm, void* instance, uint32_t id) {
 
 // The Vector.new(x, y) function.
 void _vecNew(PKVM* vm) {
-  double x, y; // The args.
-  
+  double x, y;  // The args.
+
   // Get the args from the stack, If it's not number, return.
   if (!pkGetArgNumber(vm, 1, &x)) return;
   if (!pkGetArgNumber(vm, 2, &y)) return;
-  
+
   // Create a new vector.
   Vector* vec = (Vector*)malloc(sizeof(Vector));
   vec->x = x, vec->y = y;
@@ -155,11 +150,11 @@ void _vecAdd(PKVM* vm) {
   Vector *v1, *v2;
   if (!pkGetArgInst(vm, 1, OBJ_VECTOR, (void**)&v1)) return;
   if (!pkGetArgInst(vm, 2, OBJ_VECTOR, (void**)&v2)) return;
-  
+
   // Create a new vector.
   Vector* v3 = (Vector*)malloc(sizeof(Vector));
   v3->x = v1->x + v2->x;
-  v3->y = v1->y + v2->y;  
+  v3->y = v1->y + v2->y;
 
   pkReturnInstNative(vm, (void*)v3, OBJ_VECTOR);
 }
@@ -168,8 +163,8 @@ void _vecAdd(PKVM* vm) {
 void registerVector(PKVM* vm) {
   PkHandle* vector = pkNewModule(vm, "Vector");
 
-  pkModuleAddFunction(vm, vector, "new",  _vecNew,  2);
-  pkModuleAddFunction(vm, vector, "add",  _vecAdd,  2);
+  pkModuleAddFunction(vm, vector, "new", _vecNew, 2);
+  pkModuleAddFunction(vm, vector, "add", _vecAdd, 2);
 
   pkReleaseHandle(vm, vector);
 }
@@ -179,37 +174,32 @@ void registerVector(PKVM* vm) {
 /*****************************************************************************/
 
 // Error report callback.
-void reportError(PKVM* vm, PkErrorType type,
-                 const char* file, int line,
+void reportError(PKVM* vm, PkErrorType type, const char* file, int line,
                  const char* message) {
   fprintf(stderr, "Error: %s\n", message);
 }
 
 // print() callback to write stdout.
-void stdoutWrite(PKVM* vm, const char* text) {
-  fprintf(stdout, "%s", text);
-}
-
+void stdoutWrite(PKVM* vm, const char* text) { fprintf(stdout, "%s", text); }
 
 int main(int argc, char** argv) {
-
   PkConfiguration config = pkNewConfiguration();
-  config.error_fn           = reportError;
-  config.write_fn           = stdoutWrite;
-  //config.read_fn          = stdinRead;
-  config.inst_free_fn       = freeObj;
-  config.inst_name_fn       = getObjName;
+  config.error_fn = reportError;
+  config.write_fn = stdoutWrite;
+  // config.read_fn          = stdinRead;
+  config.inst_free_fn = freeObj;
+  config.inst_name_fn = getObjName;
   config.inst_get_attrib_fn = objGetAttrib;
   config.inst_set_attrib_fn = objSetAttrib;
 
   PKVM* vm = pkNewVM(&config);
   registerVector(vm);
-  
-  PkStringPtr source = { code, NULL, NULL, 0, 0 };
-  PkStringPtr path = { "./some/path/", NULL, NULL, 0, 0 };
-  
-  PkResult result = pkInterpretSource(vm, source, path, NULL/*options*/);
+
+  PkStringPtr source = {code, NULL, NULL, 0, 0};
+  PkStringPtr path = {"./some/path/", NULL, NULL, 0, 0};
+
+  PkResult result = pkInterpretSource(vm, source, path, NULL /*options*/);
   pkFreeVM(vm);
-  
+
   return result;
 }


### PR DESCRIPTION
This is based on Google's style which looks like being the most similar
to the current style.
The thirty party libraries are excluded and won't be formatted.
Added `format` target in the Makefile to automatically format all files.